### PR TITLE
add if weights is not None in fill_n histogram1d

### DIFF
--- a/physt/histogram1d.py
+++ b/physt/histogram1d.py
@@ -431,7 +431,7 @@ class Histogram1D(HistogramBase):
         if self._binning.is_adaptive():
             map = self._binning.force_bin_existence(values)
             self._reshape_data(self._binning.bin_count, map)
-        if weights:
+        if weights is not None:
             weights = np.asarray(weights)
             self._coerce_dtype(weights.dtype)
         (frequencies, errors2, underflow, overflow, stats) = \


### PR DESCRIPTION
Fix  the raise of this error

```
ValueError: The truth value of an array with more than one element is ambiguous. 
Use a.any() or a.all()
```

when providing an array of `weights` to `fill_n`.