### PR TITLE
Unpin numpy 2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ classifiers = [
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
 dependencies = [
-    "numpy>=1.22,<2.0",
+    "numpy>=1.22",
     "packaging",
     "typing_extensions",
     "hypothesis>=6.96.1",

--- a/src/physt/helpers/__init__.py
+++ b/src/physt/helpers/__init__.py
@@ -1,0 +1,18 @@
+"""Helper functions"""
+from collections.abc import Callable
+import warnings
+
+class deprecate(object):
+    """Decorate a function to emit a DeprecationWarning."""
+
+    def __init__(self, message: str=""):
+        self.message = message
+    
+    def __call__(self, func: Callable) -> Callable: 
+        """Emit DeprecationWarning and call the funcion."""
+
+        def wrapped_func(*args, **kwargs):
+            warnings.warn(self.message, DeprecationWarning, stacklevel=2)
+            return func(*args, **kwargs)
+    
+        return wrapped_func

--- a/src/physt/histogram1d.py
+++ b/src/physt/histogram1d.py
@@ -13,6 +13,7 @@ from physt._construction import (
     extract_1d_array,
     extract_weights,
 )
+from physt.helpers import deprecate
 from physt.histogram_base import HistogramBase
 from physt.statistics import INVALID_STATISTICS, Statistics
 
@@ -322,23 +323,23 @@ class Histogram1D(ObjectWithBinning, HistogramBase):
     def inner_missed(self, value):
         self._missed[2] = value
 
-    @np.deprecate(message="Please use .statistics.mean instead.")
+    @deprecate(message="Please use .statistics.mean instead.")
     def mean(self) -> float:
         return self.statistics.mean()
 
-    @np.deprecate(message="Please use .statistics.min instead.")
+    @deprecate(message="Please use .statistics.min instead.")
     def min(self) -> float:
         return self.statistics.min
 
-    @np.deprecate(message="Please use .statistics.max instead.")
+    @deprecate(message="Please use .statistics.max instead.")
     def max(self) -> float:
         return self.statistics.max
 
-    @np.deprecate(message="Please use .statistics.std instead.")
+    @deprecate(message="Please use .statistics.std instead.")
     def std(self) -> float:  # , ddof=0):
         return self.statistics.std()
 
-    @np.deprecate(message="Please use .statistics.variance instead.")
+    @deprecate(message="Please use .statistics.variance instead.")
     def variance(self) -> float:  # , ddof: int = 0) -> float:
         return self.statistics.variance()
 


### PR DESCRIPTION
There shouldn't be a reason to restrict yourself to numpy < 2 just because of a stupid decorator.