### PR TITLE
Frozen binnings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ dependencies = [
     "narwhals>=2.0.1",
     "rich>=14.1.0",
     "basedpyright>=1.39.9",
+    "attrs>=26.1.0",
 ]
 
 [dependency-groups]

--- a/src/physt/_construction.py
+++ b/src/physt/_construction.py
@@ -490,7 +490,12 @@ def calculate_1d_frequencies(
 
 
 def calculate_1d_bins(
-    array: np.ndarray | None, _: Any = None, *, check_nan: bool = True, **kwargs
+    array: np.ndarray | None,
+    _: Any = None,
+    *,
+    check_nan: bool = True,
+    range: tuple[float, float] | None = None,
+    **kwargs,
 ) -> BinningBase:
     """Find optimal binning from arguments.
 
@@ -513,7 +518,7 @@ def calculate_1d_bins(
         if check_nan:
             if np.any(np.isnan(array)):
                 raise ValueError("Cannot calculate bins in presence of NaN's.")
-        if kwargs.get("range"):  # TODO: re-consider the usage of this parameter
+        if range:  # TODO: re-consider the usage of this parameter
             array = array[(array >= kwargs["range"][0]) & (array <= kwargs["range"][1])]
     if _ is None:
         bin_count = (

--- a/src/physt/_construction.py
+++ b/src/physt/_construction.py
@@ -495,7 +495,6 @@ def calculate_1d_bins(
     /,
     *,
     check_nan: bool = True,
-    range: tuple[float, float] | None = None,
     **kwargs,
 ) -> BinningBase:
     """Find optimal binning from arguments.
@@ -519,8 +518,7 @@ def calculate_1d_bins(
         if check_nan:
             if np.any(np.isnan(array)):
                 raise ValueError("Cannot calculate bins in presence of NaN's.")
-        if "range" in kwargs:  # TODO: re-consider the usage of this parameter
-            range = kwargs["range"]
+        if range := kwargs.get("range"):
             array = array[(array >= range[0]) & (array <= range[1])]
 
     match _:
@@ -563,6 +561,7 @@ def calculate_1d_bins(
 def calculate_nd_bins(
     array: np.ndarray | None,
     bins=None,
+    *,
     dim: int | None = None,
     check_nan: bool = True,
     **kwargs,

--- a/src/physt/_construction.py
+++ b/src/physt/_construction.py
@@ -519,7 +519,7 @@ def calculate_1d_bins(
             if np.any(np.isnan(array)):
                 raise ValueError("Cannot calculate bins in presence of NaN's.")
         if range:  # TODO: re-consider the usage of this parameter
-            array = array[(array >= kwargs["range"][0]) & (array <= kwargs["range"][1])]
+            array = array[(array >= range[0]) & (array <= range[1])]
     if _ is None:
         bin_count = (
             10  # kwargs.pop("bins", ideal_bin_count(data=array)) - same as numpy
@@ -545,6 +545,7 @@ def calculate_1d_bins(
         else:
             raise ValueError(f"No binning method '{_}' available.")
     elif callable(_):
+        # TODO: What about passing range?
         binning = _(array, **kwargs)
         if not isinstance(binning, BinningBase):
             raise TypeError(

--- a/src/physt/_construction.py
+++ b/src/physt/_construction.py
@@ -492,6 +492,7 @@ def calculate_1d_frequencies(
 def calculate_1d_bins(
     array: np.ndarray | None,
     _: Any = None,
+    /,
     *,
     check_nan: bool = True,
     range: tuple[float, float] | None = None,
@@ -518,47 +519,44 @@ def calculate_1d_bins(
         if check_nan:
             if np.any(np.isnan(array)):
                 raise ValueError("Cannot calculate bins in presence of NaN's.")
-        if range:  # TODO: re-consider the usage of this parameter
+        if "range" in kwargs:  # TODO: re-consider the usage of this parameter
+            range = kwargs["range"]
             array = array[(array >= range[0]) & (array <= range[1])]
-    if _ is None:
-        bin_count = (
-            10  # kwargs.pop("bins", ideal_bin_count(data=array)) - same as numpy
-        )
-        binning = numpy_binning(array, bin_count, **kwargs)
-    elif isinstance(_, BinningBase):
-        binning = _
-    elif isinstance(_, int):
-        binning = numpy_binning(array, _, **kwargs)
-    elif isinstance(_, str):
-        # What about the ranges???
-        if _ in bincount_methods:
+
+    match _:
+        case None:
+            binning = numpy_binning(array, 10, **kwargs)
+        case BinningBase():
+            binning = _
+        case int(n):
+            binning = numpy_binning(array, n, **kwargs)
+        case str(name) if name in bincount_methods:
             # TODO: Do we really want this?
             if array is None:
                 raise ValueError(
-                    f"Cannot find the ideal number of bins without data (method='{_}')"
+                    f"Cannot find the ideal number of bins without data (method='{name}')"
                 )
-            bin_count = ideal_bin_count(array, method=_)
+            bin_count = ideal_bin_count(array, method=name)
             binning = numpy_binning(array, bin_count, **kwargs)
-        elif _ in binning_methods:
-            method = binning_methods[_]
+        case str(name) if name in binning_methods:
+            method = binning_methods[name]
             binning = method(array, **kwargs)
-        else:
-            raise ValueError(f"No binning method '{_}' available.")
-    elif callable(_):
-        # TODO: What about passing range?
-        binning = _(array, **kwargs)
-        if not isinstance(binning, BinningBase):
-            raise TypeError(
-                f"The callable passed for bins should return a BinningBase, not {binning.__class__.__name__}"
-            )
-    elif np.iterable(_):
-        if isinstance(_, list):
-            warnings.warn(
-                "Using `list` for bins not recommended, it has different meaning with N-D histograms."
-            )
-        binning = static_binning(array, bins=_, **kwargs)
-    else:
-        raise ValueError(f"Binning {_} not understood.")
+        case str(name):
+            raise ValueError(f"Unknown binning method '{name}'")
+        case bins if np.iterable(bins):
+            if isinstance(bins, list):
+                warnings.warn(
+                    "Using `list` for bins not recommended, it has different meaning with N-D histograms."
+                )
+            binning = static_binning(array, bins=_, **kwargs)
+        case f if callable(f):
+            binning = f(array, **kwargs)
+            if not isinstance(binning, BinningBase):
+                raise TypeError(
+                    f"The callable passed for bins should return a BinningBase, not {binning.__class__.__name__}"
+                )
+        case other:
+            raise ValueError(f"Binning {other} not understood.")
     return binning
 
 

--- a/src/physt/_facade.py
+++ b/src/physt/_facade.py
@@ -139,6 +139,7 @@ def h1(
         name=name,
         axis_name=axis_name,
         title=title,
+        adaptive=adaptive,
     )
 
 
@@ -243,13 +244,14 @@ def h(
         axis_names=axis_names,
         name=name,
         title=title,
+        adaptive=adaptive,
     )
 
 
 # Aliases
 histogram = h1
-histogram2d = deprecation_alias(h2, "histogram2d")
-histogramdd = deprecation_alias(h, "histogramdd")
+histogram2d = deprecation_alias(h2, "histogram2d", "0.10")
+histogramdd = deprecation_alias(h, "histogramdd", "0.10")
 
 
 def collection(data, bins=10, **kwargs) -> HistogramCollection:

--- a/src/physt/_facade.py
+++ b/src/physt/_facade.py
@@ -115,7 +115,6 @@ def h1(
         array,
         bins,
         check_nan=not dropna and array is not None,
-        adaptive=adaptive,
         **kwargs,
     )
 
@@ -229,9 +228,7 @@ def h(
 
     weights = extract_weights(weights, array_mask=array_mask)
 
-    bin_schemas = calculate_nd_bins(
-        array, bins, dim=dim, check_nan=check_nan, adaptive=adaptive, **kwargs
-    )
+    bin_schemas = calculate_nd_bins(array, bins, dim=dim, check_nan=check_nan, **kwargs)
 
     # Prepare remaining data
     klass: type[HistogramND] = Histogram2D if dim == 2 else HistogramND  # type: ignore

--- a/src/physt/_util.py
+++ b/src/physt/_util.py
@@ -68,24 +68,33 @@ P = ParamSpec("P")
 R = TypeVar("R")
 
 
-def deprecation_alias(f: Callable[P, R], deprecated_name: str) -> Callable[P, R]:
+def deprecation_alias(
+    f: Callable[P, R], deprecated_name: str, remove_version: str | None = None
+) -> Callable[P, R]:
     """Provide a deprecated copy of a function.
 
     Parameters
     ----------
     f : The correct function
     deprecated_name : The name the function will be given
+    remove_version : The version the function will be removed
 
     Examples
     --------
     >>> def new(x): return 1
-    >>> old = deprecation_alias(new, "old")
+    >>> old = deprecation_alias(new, "old", "1.0")
     """
 
     @wraps(f)
     def inner(*args, **kwargs):
+        message = (
+            f"{deprecated_name} is deprecated"
+            + f" and will be removed in {remove_version}"
+            if remove_version
+            else "" + f", use {f.__name__} instead"
+        )
         warnings.warn(
-            f"{deprecated_name} is deprecated, use {f.__name__} instead",
+            message,
             FutureWarning,
         )
         return f(*args, **kwargs)

--- a/src/physt/binnings.py
+++ b/src/physt/binnings.py
@@ -420,10 +420,10 @@ class FixedWidthBinning(EdgeBasedBinning):
 
     bin_count: int = attrs.field(default=0)
     bin_width: float = attrs.field(converter=float)
-    times_min: int | None = attrs.field(default=None)
-    shift: float = 0.0
+    bin_times_min: int | None = attrs.field(default=None)
+    bin_shift: float = 0.0
 
-    @times_min.validator
+    @bin_times_min.validator
     def _validate_times_min(self, attribute, value):
         if value is None and self.bin_count > 0:
             raise ValueError("times_min must be defined when bin_count > 0.")
@@ -465,8 +465,8 @@ class FixedWidthBinning(EdgeBasedBinning):
         return cls(
             bin_width=bin_width,
             bin_count=bin_count,
-            times_min=times_min,
-            shift=shift,
+            bin_times_min=times_min,
+            bin_shift=shift,
             includes_right_edge=includes_right_edge,
         )
 
@@ -503,7 +503,7 @@ class FixedWidthBinning(EdgeBasedBinning):
 
     def coerce_values(self, values: ArrayLike) -> tuple["BinningBase", int | None]:
         if self.bin_count == 0:
-            if self.shift:
+            if self.bin_shift:
                 # TODO: Implement this
                 raise NotImplementedError()
             return fixed_width_binning(values, bin_width=self.bin_width), None
@@ -519,19 +519,19 @@ class FixedWidthBinning(EdgeBasedBinning):
         new_binning = attrs.evolve(
             self,
             bin_count=self.bin_count + add_left + add_right,
-            times_min=self.times_min - add_left,
+            bin_times_min=self.bin_times_min - add_left,
         )
         return new_binning, add_left
 
     @property
     def first_edge(self) -> float:
-        return self.bin_width * self._validate_times_min() + self.shift
+        return self.bin_width * self._validate_times_min() + self.bin_shift
 
     @property
     def last_edge(self) -> float:
         return (
             self._validate_times_min() + self.bin_count
-        ) * self.bin_width + self.shift
+        ) * self.bin_width + self.bin_shift
 
     @property
     # TODO: Cache this
@@ -540,15 +540,15 @@ class FixedWidthBinning(EdgeBasedBinning):
             return np.zeros((0, 2), dtype=float)
         return (
             self._validate_times_min() + np.arange(self.bin_count + 1, dtype=int)
-        ) * self.bin_width + self.shift
+        ) * self.bin_width + self.bin_shift
 
     def _validate_times_min(self) -> int:
         """Check the binning is well-defined and return the times min."""
-        if self.times_min is None:
+        if self.bin_times_min is None:
             raise ValueError(
                 "No bins and not enough information to provide first edge."
             )
-        return self.times_min
+        return self.bin_times_min
 
     def _coerce(
         self, other: BinningBase
@@ -558,9 +558,9 @@ class FixedWidthBinning(EdgeBasedBinning):
             raise ValueError(
                 f"Cannot coerce fixed-width histograms with different bin widths: {self.bin_width} vs {other.bin_width}."
             )
-        if self.shift != other.shift:
+        if self.bin_shift != other.bin_shift:
             raise ValueError(
-                f"Cannot coerce shifted fixed-width histograms: {self.shift} vs {other.shift}"
+                f"Cannot coerce shifted fixed-width histograms: {self.bin_shift} vs {other.bin_shift}"
             )
 
         # Trivial cases
@@ -569,19 +569,19 @@ class FixedWidthBinning(EdgeBasedBinning):
         if other.bin_count == 0:
             return self, None, None
 
-        new_times_min = min(self.times_min, other.times_min)
+        new_times_min = min(self.bin_times_min, other.bin_times_min)
         new_times_max = max(
-            self.times_min + self.bin_count, other.times_min + other.bin_count
+            self.bin_times_min + self.bin_count, other.bin_times_min + other.bin_count
         )
         result = FixedWidthBinning(
             bin_width=self.bin_width,
-            times_min=new_times_min,
+            bin_times_min=new_times_min,
             bin_count=new_times_max - new_times_min,
-            shift=self.shift,
+            bin_shift=self.bin_shift,
         )
 
-        bin_map1 = self.times_min - new_times_min
-        bin_map2 = other.times_min - new_times_min
+        bin_map1 = self.bin_times_min - new_times_min
+        bin_map2 = other.bin_times_min - new_times_min
         return result, bin_map1, bin_map2
 
     def as_fixed_width(self, *, copy: bool = True) -> "FixedWidthBinning":
@@ -593,8 +593,8 @@ class FixedWidthBinning(EdgeBasedBinning):
         # TODO: Fix to be instantiable from JSON
         a_dict["bin_count"] = self.bin_count
         a_dict["bin_width"] = self.bin_width
-        a_dict["bin_shift"] = self.shift
-        a_dict["bin_times_min"] = self.times_min
+        a_dict["bin_shift"] = self.bin_shift
+        a_dict["bin_times_min"] = self.bin_times_min
 
 
 @attrs.define(frozen=True, kw_only=True)
@@ -819,7 +819,9 @@ def integer_binning(
         kwargs["range"] = tuple(r - 0.5 for r in range)
     else:
         kwargs["shift"] = 0.5
-    return fixed_width_binning(data=data, bin_width=bin_width, align=False, **kwargs)
+    return fixed_width_binning(
+        data=data, bin_width=bin_width, align=False, includes_right_edge=True, **kwargs
+    )
 
 
 @register_binning()
@@ -880,7 +882,7 @@ def fixed_width_binning(
     return FixedWidthBinning(
         bin_width=bin_width,
         includes_right_edge=includes_right_edge,
-        shift=shift or 0.0,
+        bin_shift=shift or 0.0,
     )
 
 

--- a/src/physt/binnings.py
+++ b/src/physt/binnings.py
@@ -8,6 +8,7 @@ from collections.abc import Iterable
 from contextlib import suppress
 from typing import TYPE_CHECKING, ParamSpec, TypeAlias, TypeVar, cast, final, overload
 
+import attrs
 import numpy as np
 from typing_extensions import Self, override
 
@@ -63,8 +64,7 @@ def register_binning(name: str | None = None) -> Callable[[Callable], Callable]:
     return decorator
 
 
-# TODO: Locking and edit operations (like numpy read-only)
-# TODO: Using pydantic models strongly recommended here
+@attrs.define(frozen=True)
 class BinningBase(ABC):
     """Abstract base class for binning schemas.
 
@@ -84,21 +84,23 @@ class BinningBase(ABC):
     inconsecutive_allowed: ClassVar[bool] = False
     """Whether it is possible to have bins with gaps."""
 
-    def __init__(
-        self,
-        *,
-        includes_right_edge: bool = False,
-        adaptive: bool = False,
-    ):
-        # TODO: Incorporate integrity_check?
-        self._includes_right_edge: bool = includes_right_edge
-        if adaptive and not self.adaptive_allowed:
+    adaptive: bool = attrs.field(default=False, kw_only=True)
+    """Whether the binning is adaptive (bins are updated dynamically)."""
+
+    @adaptive.validator
+    def _validate_adaptive(self, attribute, value) -> bool:
+        if value and not self.adaptive_allowed:
             raise ValueError(f"Adaptivity not allowed for {self.__class__.__name__}.")
-        if adaptive and includes_right_edge:
+        return value
+
+    includes_right_edge: bool = attrs.field(default=False, kw_only=True)
+    """Whether the right edge of the last bin is included in the binning."""
+
+    def __attrs_post_init__(self):
+        if self.includes_right_edge and self.adaptive:
             raise ValueError(
                 "Adaptivity does not work together with right-edge inclusion."
             )
-        self._adaptive: bool = adaptive
 
     @overload
     def __getitem__(self, index: slice) -> StaticBinning: ...
@@ -108,9 +110,11 @@ class BinningBase(ABC):
 
     def __getitem__(self, index: slice | int) -> StaticBinning | EdgePair:
         if isinstance(index, slice):
-            new_binning = self.as_static()
-            new_binning._bins = new_binning.bins[index]
-            return new_binning
+            same_right_edge = self.bins[index][-1, 1] == self.bins[-1, 1]
+            return StaticBinning(
+                bins=self.bins[index],
+                includes_right_edge=same_right_edge and self.includes_right_edge,
+            )
         return self.bins[index]
 
     @staticmethod
@@ -127,7 +131,7 @@ class BinningBase(ABC):
         to add details.
         """
         result: dict[str, Any] = {
-            "adaptive": self._adaptive,
+            "adaptive": self.adaptive,
             "binning_type": type(self).__name__,
         }
         self._update_dict(result)
@@ -135,11 +139,6 @@ class BinningBase(ABC):
 
     @abstractmethod
     def _update_dict(self, a_dict: dict[str, Any]) -> None: ...
-
-    @property
-    def includes_right_edge(self) -> bool:
-        # TODO: Document and explain
-        return self._includes_right_edge
 
     def is_regular(self, *, rtol: float = 1.0e-5, atol: float = 1.0e-8) -> bool:
         """Whether all bins have the same width.
@@ -162,10 +161,6 @@ class BinningBase(ABC):
         if self.inconsecutive_allowed:
             return is_consecutive(self.bins, rtol=rtol, atol=atol)
         return True
-
-    def is_adaptive(self) -> bool:
-        """Whether the binning can be adapted to include values not currently spanned."""
-        return self._adaptive
 
     @final
     def force_bin_existence(self, values: ArrayLike) -> int | BinMap | None:
@@ -223,15 +218,6 @@ class BinningBase(ABC):
         # Implement this if appropriate. It cannot be an abstract method.
         raise RuntimeError(f"Cannot adapt {self.__class__.__name__}.")
 
-    def set_adaptive(self, value: bool = True) -> None:
-        """Set/unset the adaptive property of the binning.
-
-        This is available only for some of the binning types.
-        """
-        if value and not self.adaptive_allowed:
-            raise RuntimeError("Cannot change binning to adaptive.")
-        self._adaptive = value
-
     def __eq__(self, other: object) -> bool:
         if self is other:
             return True
@@ -271,6 +257,7 @@ class BinningBase(ABC):
         """
 
     @property
+    @abstractmethod
     def numpy_bins_with_mask(self) -> tuple[np.ndarray, np.ndarray]:
         """Bins in the numpy format, including the gaps in inconsecutive binnings.
 
@@ -282,10 +269,6 @@ class BinningBase(ABC):
         --------
         bin_utils.to_numpy_bins_with_mask
         """
-        edges, mask = to_numpy_bins_with_mask(self.bins)
-        if not self.includes_right_edge:
-            edges = np.concatenate([edges, np.asarray([np.inf])])
-        return edges, mask
 
     # TODO: is this used?
     @property
@@ -299,7 +282,7 @@ class BinningBase(ABC):
         """The right edge of the last bin."""
         return self.bins[-1, 1].item()
 
-    def as_static(self, copy: bool = True) -> "StaticBinning":  # pylint: disable=unused-argument
+    def as_static(self, *, copy: bool = True) -> "StaticBinning":  # pylint: disable=unused-argument
         """Convert binning to a static form.
 
         Parameters
@@ -312,11 +295,13 @@ class BinningBase(ABC):
         StaticBinning
             A new static binning with a copy of bins.
         """
+        if not copy:
+            return self
         return StaticBinning(
             bins=self.bins.copy(), includes_right_edge=self.includes_right_edge
         )
 
-    def as_fixed_width(self, copy: bool = True) -> "FixedWidthBinning":  # pylint: disable=unused-argument
+    def as_fixed_width(self, *, copy: bool = True) -> "FixedWidthBinning":  # pylint: disable=unused-argument
         """Convert binning to recipe with fixed width (if possible).
 
         Parameters
@@ -336,9 +321,9 @@ class BinningBase(ABC):
                 "Cannot create fixed-width binning from differing bin widths."
             )
 
-    @abstractmethod
     def copy(self) -> Self:
         """Create an identical, independent copy."""
+        return attrs.evolve(self)
 
     def apply_bin_map(self, bin_map: BinMap) -> "BinningBase":
         """...
@@ -370,31 +355,33 @@ class BinningBase(ABC):
         return f"{self.__class__.__name__}({self.numpy_bins!r})"
 
 
+@attrs.define(frozen=True)
 class StaticBinning(BinningBase):
     """Binning defined by an array of bin edge pairs."""
 
+    bins: np.ndarray = attrs.field(converter=make_bin_array)
+
     inconsecutive_allowed: ClassVar[bool] = True
 
-    _bins: np.ndarray
-
-    def __init__(self, bins: ArrayLike, includes_right_edge: bool = True, **kwargs):
-        super().__init__(includes_right_edge=includes_right_edge)
-        bins = make_bin_array(bins)
-        if not is_rising(bins):
+    @bins.validator
+    def _validate_rising_bins(self, attribute, value):
+        if not is_rising(value):
             raise ValueError("Bins must be in rising order.")
-        self._bins = bins
-
-    @property
-    def bins(self) -> np.ndarray:
-        return self._bins
 
     @property
     def bin_count(self) -> int:
-        return self._bins.shape[0]
+        return self.bins.shape[0]
 
     @property
     def numpy_bins(self) -> np.ndarray:
-        return to_numpy_bins(self._bins)
+        return to_numpy_bins(self.bins)
+
+    @property
+    def numpy_bins_with_mask(self) -> tuple[np.ndarray, np.ndarray]:
+        edges, mask = to_numpy_bins_with_mask(self.bins)
+        if not self.includes_right_edge:
+            edges = np.concatenate([edges, np.asarray([np.inf])])
+        return edges, mask
 
     def as_static(self, copy: bool = True) -> "StaticBinning":
         if copy:
@@ -405,12 +392,6 @@ class StaticBinning(BinningBase):
         return type(self)(
             bins=self.bins.copy(), includes_right_edge=self.includes_right_edge
         )
-
-    def __getitem__(self, item):
-        copy = self.copy()
-        copy._bins = self._bins[item]
-        # TODO: check for the right_edge??
-        return copy
 
     def _update_dict(self, a_dict: dict[str, Any]) -> None:
         a_dict["bins"] = self.bins.tolist()
@@ -425,15 +406,27 @@ class StaticBinning(BinningBase):
         return f"{self.__class__.__name__}({self.bins!r})"
 
 
-class _NumpyLikeBinning(BinningBase, ABC):
-    """Binning that provides numpy_bins and derives bins from it."""
+@attrs.define(frozen=True, kw_only=True)
+class EdgeBasedBinning(BinningBase, ABC):
+    """Binning that provides edges and derives bins from it.
+
+    Note: Thus, it cannot be inconsecutive.
+    """
 
     @property
     @override
     def bins(self) -> np.ndarray:
         return make_bin_array(self.numpy_bins)
 
-    # TODO: Add custom numpy_bins_with_mask
+    @property
+    def numpy_bins_with_mask(self) -> tuple[np.ndarray, np.ndarray]:
+        if self.includes_right_edge:
+            edges = np.concatenate([self.numpy_bins, np.asarray([np.inf])])
+            mask = np.arange(self.numpy_bins.shape[0], dtype=int)
+        else:
+            edges = self.numpy_bins
+            mask = np.arange(self.numpy_bins.shape[0] - 1, dtype=int)
+        return edges, mask
 
     @property
     @override
@@ -441,81 +434,72 @@ class _NumpyLikeBinning(BinningBase, ABC):
         return self.numpy_bins.shape[0] - 1
 
 
-class NumpyBinning(_NumpyLikeBinning):
+@attrs.define(frozen=True, kw_only=True)
+class NumpyBinning(EdgeBasedBinning):
     """Binning schema working as numpy.histogram."""
 
-    def __init__(
-        self, numpy_bins: ArrayLike, *, includes_right_edge: bool = True, **kwargs
-    ):
-        numpy_bins = np.asarray(numpy_bins)
-        if not is_rising(numpy_bins):
-            raise ValueError("Bins not in rising order.")
-        super().__init__(includes_right_edge=includes_right_edge, **kwargs)
-        self._numpy_bins: np.ndarray = np.asarray(numpy_bins)
+    numpy_bins: np.ndarray = attrs.field(converter=np.asarray)
 
-    @property
-    def numpy_bins(self) -> np.ndarray:
-        return self._numpy_bins
-
-    def copy(self) -> NumpyBinning:
-        return NumpyBinning(
-            numpy_bins=self.numpy_bins, includes_right_edge=self.includes_right_edge
-        )
+    @numpy_bins.validator
+    def _validate_rising_bins(self, attribute, value):
+        if not is_rising(value):
+            raise ValueError("Bins must be in rising order.")
 
     def _update_dict(self, a_dict: dict[str, Any]) -> None:
         a_dict["numpy_bins"] = self.numpy_bins.tolist()
 
 
-class FixedWidthBinning(_NumpyLikeBinning):
+@attrs.define(frozen=True, kw_only=True)
+class FixedWidthBinning(EdgeBasedBinning):
     """Binning schema with predefined bin width."""
 
     adaptive_allowed: ClassVar[bool] = True
 
-    _bin_width: float
-    _bin_count: int
-    _times_min: int | None
-    _shift: float
+    bin_count: int = attrs.field(default=0)
+    bin_width: float = attrs.field(default=1.0, converter=float)
+    times_min: int | None = attrs.field(default=None)
+    shift: float = 0.0
 
-    def __init__(
-        self,
+    @times_min.validator
+    def _validate_times_min(self, attribute, value):
+        if value is None and self.bin_count > 0:
+            raise ValueError("times_min must be defined when bin_count > 0.")
+        return value
+
+    @bin_count.validator
+    def _validate_bin_count(self, attribute, value):
+        if value < 0:
+            raise ValueError("bin_count must be >= 0.")
+        return value
+
+    @bin_width.validator
+    def _validate_bin_width(self, attribute, value):
+        if value <= 0:
+            raise ValueError("bin_width must be > 0.")
+        return value
+
+    @classmethod
+    def create_from_min_max(
+        cls,
         *,
+        min_: float,
+        max_: float,
         bin_width: float,
-        bin_count: int = 0,
-        bin_times_min: int | None = None,
-        # TODO: move this to the helper method?
-        min: float | None = None,
         includes_right_edge: bool = False,
-        adaptive: bool = False,
-        bin_shift: float | None = None,
-        **kwargs,
-    ):
-        super().__init__(adaptive=adaptive, includes_right_edge=includes_right_edge)
-        # TODO: Check edge cases for min/shift/align
-        if bin_width <= 0:
-            raise ValueError("Bin width must be > 0.")
-        if bin_count < 0:
-            raise ValueError("Bin count must be >= 0.")
-        if (bin_times_min is not None or bin_shift is not None) and (min is not None):
-            raise ValueError("Cannot specify both min and (times_min or shift)")
-        self._bin_width = float(bin_width)
-        self._bin_count = int(bin_count)
-        if min is not None:
-            times_min = int(np.floor(min / self.bin_width))
-            self._shift = min - times_min * self.bin_width
-            self._times_min = times_min
-        else:
-            self._shift = bin_shift or 0.0
-            self._times_min = bin_times_min
-
-    def copy(self) -> FixedWidthBinning:
-        result = FixedWidthBinning.__new__(FixedWidthBinning)
-        result._bin_width = self._bin_width
-        result._bin_count = self._bin_count
-        result._times_min = self._times_min
-        result._shift = self._shift
-        result._adaptive = self._adaptive
-        result._includes_right_edge = self._includes_right_edge
-        return result
+        align: bool = True,
+    ) -> "FixedWidthBinning":
+        times_min = int(np.floor(min_ / bin_width))
+        shift = 0 if align else min_ - times_min * bin_width
+        bin_count = max(1, int(np.floor(max_ - (times_min * bin_width + shift))))
+        if includes_right_edge and shift + bin_count * bin_width == max_:
+            bin_count += 1
+        return cls(
+            bin_width=bin_width,
+            bin_count=bin_count,
+            times_min=times_min,
+            shift=shift,
+            includes_right_edge=includes_right_edge,
+        )
 
     @override
     def __repr__(self):
@@ -532,7 +516,7 @@ class FixedWidthBinning(_NumpyLikeBinning):
 
     def _force_bin_existence_single(
         self, value: float, *, includes_right_edge: bool | None = None
-    ) -> int | None:
+    ) -> tuple["FixedWidthBinning", int | None]:
         if includes_right_edge is None:
             includes_right_edge = self.includes_right_edge
 
@@ -591,28 +575,19 @@ class FixedWidthBinning(_NumpyLikeBinning):
     @property
     # TODO: Cache this
     def numpy_bins(self) -> np.ndarray:
-        if self._bin_count == 0:
+        if not self.bin_count:
             return np.zeros((0, 2), dtype=float)
         return (
-            self._validate_times_min() + np.arange(self._bin_count + 1, dtype=int)
-        ) * self._bin_width + self._shift
-
-    @property
-    def bin_count(self) -> int:
-        return self._bin_count
-
-    @property
-    def bin_width(self) -> float:
-        return self._bin_width
+            self._validate_times_min() + np.arange(self.bin_count + 1, dtype=int)
+        ) * self.bin_width + self.shift
 
     def _validate_times_min(self) -> int:
         """Check the binning is well-defined and return the times min."""
-        if self._times_min is None:
-            assert not self._bin_count  # This should never occur
+        if self.times_min is None:
             raise ValueError(
                 "No bins and not enough information to provide first edge."
             )
-        return self._times_min
+        return self.times_min
 
     def _force_new_min_max(self, new_min, new_max) -> BinMap | None:
         bin_map = None
@@ -663,7 +638,7 @@ class FixedWidthBinning(_NumpyLikeBinning):
         bin_map2 = other._force_new_min_max(new_min, new_max)
         return bin_map1, bin_map2
 
-    def as_fixed_width(self, copy: bool = True) -> "FixedWidthBinning":
+    def as_fixed_width(self, *, copy: bool = True) -> "FixedWidthBinning":
         if copy:
             return self.copy()
         return self
@@ -672,56 +647,39 @@ class FixedWidthBinning(_NumpyLikeBinning):
         # TODO: Fix to be instantiable from JSON
         a_dict["bin_count"] = self.bin_count
         a_dict["bin_width"] = self.bin_width
-        a_dict["bin_shift"] = self._shift
-        a_dict["bin_times_min"] = self._times_min
+        a_dict["bin_shift"] = self.shift
+        a_dict["bin_times_min"] = self.times_min
 
 
-class ExponentialBinning(_NumpyLikeBinning):
+@attrs.define(frozen=True, kw_only=True)
+class ExponentialBinning(EdgeBasedBinning):
     """Binning schema with exponentially distributed bins."""
 
     adaptive_allowed: ClassVar[bool] = False
 
-    # TODO: Implement adaptivity
+    bin_count: int = attrs.field()
+    log_min: float
+    log_width: float
 
-    def __init__(
-        self,
-        *,
-        log_min: float,
-        log_width: float,
-        bin_count: int,
-        includes_right_edge: bool = True,
-        adaptive: bool = False,
-        **kwargs,
-    ):
-        super(ExponentialBinning, self).__init__(
-            includes_right_edge=includes_right_edge, adaptive=adaptive
-        )
-        self._log_min: float = log_min
-        self._log_width: float = log_width
-        self._bin_count: int = bin_count
+    @bin_count.validator
+    def _validate_bin_count(self, attribute, value):
+        if value <= 0:
+            raise ValueError("bin_count must be positive")
 
     def is_regular(self, **kwargs) -> bool:
         return False
 
     @property
     def numpy_bins(self) -> np.ndarray:
-        if self._bin_count == 0:
+        if self.bin_count == 0:
             return np.ndarray((0,), dtype=float)
-        log_bins = self._log_min + np.arange(self._bin_count + 1) * self._log_width
+        log_bins = self.log_min + np.arange(self.bin_count + 1) * self.log_width
         return 10.0**log_bins
 
-    def copy(self) -> "ExponentialBinning":
-        return ExponentialBinning(
-            log_min=self._log_min,
-            log_width=self._log_width,
-            bin_count=self._bin_count,
-            includes_right_edge=self.includes_right_edge,
-        )
-
     def _update_dict(self, a_dict: dict[str, Any]) -> None:
-        a_dict["log_min"] = self._log_min
-        a_dict["log_width"] = self._log_width
-        a_dict["bin_count"] = self._bin_count
+        a_dict["log_min"] = self.log_min
+        a_dict["log_width"] = self.log_width
+        a_dict["bin_count"] = self.bin_count
 
 
 @register_binning()
@@ -729,7 +687,6 @@ def numpy_binning(
     data: np.ndarray | None = None,
     bin_count: int = 10,
     range: RangeTuple | None = None,
-    **kwargs,
 ) -> NumpyBinning:
     """Construct binning schema compatible with numpy.histogram together with int argument
 
@@ -778,7 +735,7 @@ def numpy_binning(
                 edges_.append(np.nextafter(edges_[-1], np.inf))
             edges = np.array(edges_)
 
-    return NumpyBinning(edges)
+    return NumpyBinning(numpy_bins=edges)
 
 
 @register_binning()
@@ -790,7 +747,8 @@ def pretty_binning(
     range: RangeTuple | None = None,
     min_bin_width: float | None = None,
     max_bin_width: float | None = None,
-    **kwargs,
+    adaptive: bool = False,
+    includes_right_edge: bool = False,
 ) -> FixedWidthBinning:
     """Construct fixed-width ninning schema with bins automatically optimized to human-friendly widths.
 
@@ -826,7 +784,12 @@ def pretty_binning(
         bin_width = min(bin_width, max_bin_width)
 
     return fixed_width_binning(
-        bin_width=bin_width, data=data, range=range, align=True, **kwargs
+        bin_width=bin_width,
+        data=data,
+        range=range,
+        align=True,
+        adaptive=adaptive,
+        includes_right_edge=includes_right_edge,
     )
 
 
@@ -841,7 +804,7 @@ def quantile_binning(
     bin_count: int | None = None,
     q: Sequence[float] | None = None,
     qrange: RangeTuple | None = None,
-    **kwargs,
+    includes_right_edge: bool = True,
 ) -> StaticBinning:
     """Binning schema based on quantile ranges.
 
@@ -870,16 +833,26 @@ def quantile_binning(
     else:
         percentiles = np.asarray(q) * 100.0
     bins = np.percentile(data, percentiles)
-    return static_binning(bins=make_bin_array(bins), includes_right_edge=True)
+    return static_binning(
+        bins=make_bin_array(bins), includes_right_edge=includes_right_edge
+    )
 
 
 @register_binning()
 def static_binning(
-    data: np.ndarray | None = None, *, bins: ArrayLike, **kwargs
+    data: np.ndarray | None = None,
+    *,
+    bins: ArrayLike,
+    includes_right_edge: bool = False,
 ) -> StaticBinning:
-    """Construct static binning with whatever bins."""
+    """Construct static binning with whatever bins.
+
+    Any data passed in will be ignored.
+    """
     # TODO: Fail with no bins!
-    return StaticBinning(bins=make_bin_array(bins), **kwargs)
+    return StaticBinning(
+        bins=make_bin_array(bins), includes_right_edge=includes_right_edge
+    )
 
 
 @register_binning()
@@ -912,7 +885,8 @@ def fixed_width_binning(
     data: np.ndarray | None = None,
     bin_width: float = 1.0,
     *,
-    bin_shift: float | None = None,
+    min_: float | None = None,
+    bin_count: int | None = None,
     adaptive: bool = False,
     range: RangeTuple | None = None,
     align: bool | None = None,
@@ -926,42 +900,46 @@ def fixed_width_binning(
     range: (min, max)
     align: Must be multiple of bin_width
     """
-    if align is None:
-        align = not range and bin_shift is None
+    if data is not None or range:
+        # First try to create from limits
+        min_ = None
+        max_ = None
 
-    min_ = None
-    if align:
+        if bin_count is not None:
+            raise ValueError("Cannot set both `bin_count` and `data`/`range`.")
+
+        if data is not None:
+            arr = np.asarray(data)
+            min_ = np.min(arr)
+            max_ = np.max(arr)
+            if align is None:
+                align = True
         if range:
-            raise ValueError("Cannot set both `align` and `range`.")
-        if bin_shift:
-            raise ValueError("Cannot set `bin_shift` when `align==True`.")
-        bin_shift = 0.0
-    else:
-        # Not aligned, bin_shift will be constructed from min_
-        if bin_shift:
-            pass
-        elif range:
+            # This takes precedence over data
+            if align:
+                raise ValueError("Cannot set both `align` and `range`.")
+            if align is None:
+                # We should respect the lower bound of the range
+                align = False
+            if adaptive:
+                raise ValueError("Cannot set `adaptive` when `range` is set.")
+            align = False
             min_ = range[0]
-        elif data is not None:
-            min_ = np.min(data)
+            max_ = range[1]
 
-    result = FixedWidthBinning(
+        return FixedWidthBinning.create_from_min_max(
+            min_=min_,
+            max_=max_,
+            bin_width=bin_width,
+            align=align,
+            includes_right_edge=includes_right_edge,
+        )
+
+    return FixedWidthBinning(
         bin_width=bin_width,
         includes_right_edge=includes_right_edge,
-        min=min_,
         adaptive=adaptive,
-        bin_shift=bin_shift,
     )
-    if range:
-        result._force_bin_existence(range[0])
-        result._force_bin_existence(range[1], includes_right_edge=True)
-        if not adaptive:
-            return result  # Otherwise we want to adapt to data
-    if data is not None and data.shape[0]:
-        result._force_bin_existence(
-            [np.min(data), np.max(data)], includes_right_edge=includes_right_edge
-        )
-    return result
 
 
 @register_binning()

--- a/src/physt/binnings.py
+++ b/src/physt/binnings.py
@@ -563,11 +563,11 @@ class FixedWidthBinning(EdgeBasedBinning):
         other = other.as_fixed_width()
         if self.bin_width != other.bin_width:
             raise ValueError(
-                f"Cannot adapt fixed-width histograms with different bin widths: {self.bin_width} vs {other.bin_width}."
+                f"Cannot coerce fixed-width histograms with different bin widths: {self.bin_width} vs {other.bin_width}."
             )
         if self.shift != other.shift:
             raise ValueError(
-                f"Cannot adapt shifted fixed-width histograms: {self.shift} vs {other.shift}"
+                f"Cannot coerce shifted fixed-width histograms: {self.shift} vs {other.shift}"
             )
 
         # Trivial cases

--- a/src/physt/binnings.py
+++ b/src/physt/binnings.py
@@ -454,12 +454,12 @@ class FixedWidthBinning(EdgeBasedBinning):
             raise ValueError("Cannot align with shift.")
         times_min = int(np.floor((min_ - (shift or 0.0)) / bin_width))
         if shift is None:
-            shift = 0 if align else min_ - times_min * bin_width
-        bin_count = max(
-            1, int(np.ceil((max_ - (times_min * bin_width + shift)) / bin_width))
-        )
-        if includes_right_edge and shift + bin_count * bin_width == max_:
+            shift = 0.0 if align else min_ - times_min * bin_width
+        bin_count = int(np.ceil((max_ - (times_min * bin_width + shift)) / bin_width))
+        if not includes_right_edge and shift + bin_count * bin_width == max_:
             bin_count += 1
+        # If min == max, we might end up with 0 bins by now...
+        bin_count = max(1, bin_count)
         return cls(
             bin_width=bin_width,
             bin_count=bin_count,

--- a/src/physt/binnings.py
+++ b/src/physt/binnings.py
@@ -318,7 +318,9 @@ class BinningBase(ABC):
 class StaticBinning(BinningBase):
     """Binning defined by an array of bin edge pairs."""
 
-    bins: np.ndarray = attrs.field(converter=make_bin_array)
+    bins: np.ndarray = attrs.field(
+        converter=make_bin_array, eq=attrs.cmp_using(np.array_equal)
+    )
 
     inconsecutive_allowed: ClassVar[bool] = True
 
@@ -786,10 +788,11 @@ def static_binning(
     *,
     bins: ArrayLike,
     includes_right_edge: bool = False,
+    range: RangeTuple | None = None,
 ) -> StaticBinning:
     """Construct static binning with whatever bins.
 
-    Any data passed in will be ignored.
+    Any data passed in will be ignored. Also, range will be ignored
     """
     # TODO: Fail with no bins!
     return StaticBinning(

--- a/src/physt/binnings.py
+++ b/src/physt/binnings.py
@@ -73,34 +73,19 @@ class BinningBase(ABC):
     - define at least one of the following properties: bins, numpy_bins (cached conversion exists)
     - if you modify bins, put _bins and _numpy_bins into proper state (None may be sufficient)
     - checking of proper bins should be done in __init__
-    - if you want to support adaptive histogram, override _force_bin_existence
+    - if you want to support adaptive histogram, override force_bin_existence
     - implement _update_dict to contain the binning representation
     - the constructor (and facade methods) must accept any kwargs (and ignores those that are not used).
     """
 
-    adaptive_allowed: ClassVar[bool] = False
+    adaptable: ClassVar[bool] = False
     """Whether it is possible to update the bins dynamically."""
 
     inconsecutive_allowed: ClassVar[bool] = False
     """Whether it is possible to have bins with gaps."""
 
-    adaptive: bool = attrs.field(default=False, kw_only=True)
-    """Whether the binning is adaptive (bins are updated dynamically)."""
-
-    @adaptive.validator
-    def _validate_adaptive(self, attribute, value) -> bool:
-        if value and not self.adaptive_allowed:
-            raise ValueError(f"Adaptivity not allowed for {self.__class__.__name__}.")
-        return value
-
     includes_right_edge: bool = attrs.field(default=False, kw_only=True)
     """Whether the right edge of the last bin is included in the binning."""
-
-    def __attrs_post_init__(self):
-        if self.includes_right_edge and self.adaptive:
-            raise ValueError(
-                "Adaptivity does not work together with right-edge inclusion."
-            )
 
     @overload
     def __getitem__(self, index: slice) -> StaticBinning: ...
@@ -131,7 +116,6 @@ class BinningBase(ABC):
         to add details.
         """
         result: dict[str, Any] = {
-            "adaptive": self.adaptive,
             "binning_type": type(self).__name__,
         }
         self._update_dict(result)
@@ -162,8 +146,9 @@ class BinningBase(ABC):
             return is_consecutive(self.bins, rtol=rtol, atol=atol)
         return True
 
-    @final
-    def force_bin_existence(self, values: ArrayLike) -> int | BinMap | None:
+    def force_bin_existence(
+        self, values: ArrayLike
+    ) -> tuple["BinningBase", int | BinMap | None]:
         """Change schema so that there is a bin for value.
 
         It is necessary to implement the _force_bin_existence template method.
@@ -180,14 +165,6 @@ class BinningBase(ABC):
             otherwise => the iterable contains tuples (old bin index, new bin index)
                 new bin index can occur multiple times, which corresponds to bin merging
         """
-        if not self.is_adaptive():
-            raise RuntimeError("Histogram is not adaptive.")
-        else:
-            return self._force_bin_existence(values)
-
-    def _force_bin_existence(self, values: ArrayLike) -> int | BinMap | None:
-        # Implement this if appropriate. It cannot be an abstract method.
-        # It does not check whether the binning is adaptive
         raise NotImplementedError()
 
     @final
@@ -207,8 +184,6 @@ class BinningBase(ABC):
         ----
         Implement the `_adapt` template method.
         """
-        if not self.is_adaptive():
-            raise RuntimeError("Cannot adapt non-adaptive binning.")
         if np.array_equal(self.bins, other.bins):
             # Already adapted
             return None, None
@@ -453,7 +428,7 @@ class NumpyBinning(EdgeBasedBinning):
 class FixedWidthBinning(EdgeBasedBinning):
     """Binning schema with predefined bin width."""
 
-    adaptive_allowed: ClassVar[bool] = True
+    adaptable: ClassVar[bool] = True
 
     bin_count: int = attrs.field(default=0)
     bin_width: float = attrs.field(default=1.0, converter=float)
@@ -487,8 +462,11 @@ class FixedWidthBinning(EdgeBasedBinning):
         bin_width: float,
         includes_right_edge: bool = False,
         align: bool = True,
+        shift: float | None = None,
     ) -> "FixedWidthBinning":
-        times_min = int(np.floor(min_ / bin_width))
+        if align and shift:
+            raise ValueError("Cannot align with shift.")
+        times_min = int(np.floor(min_ - (shift or 0.0) / bin_width))
         shift = 0 if align else min_ - times_min * bin_width
         bin_count = max(1, int(np.floor(max_ - (times_min * bin_width + shift))))
         if includes_right_edge and shift + bin_count * bin_width == max_:
@@ -507,8 +485,6 @@ class FixedWidthBinning(EdgeBasedBinning):
             f"{self.__class__.__name__}(bin_width={self.bin_width}, "
             f"bin_count={self.bin_count}, min={self.first_edge}"
         )
-        if self.is_adaptive():
-            result += ", adaptive=True"
         return result + ")"
 
     def is_regular(self, **kwargs) -> bool:
@@ -543,9 +519,9 @@ class FixedWidthBinning(EdgeBasedBinning):
             else:
                 return None
 
-    def _force_bin_existence(
+    def force_bin_existence(
         self, values: ArrayLike, *, includes_right_edge=None
-    ) -> int | BinMap | None:
+    ) -> tuple[FixedWidthBinning, int | BinMap | None]:
         if np.isscalar(values):
             return self._force_bin_existence_single(
                 cast(float, values), includes_right_edge=includes_right_edge
@@ -655,7 +631,7 @@ class FixedWidthBinning(EdgeBasedBinning):
 class ExponentialBinning(EdgeBasedBinning):
     """Binning schema with exponentially distributed bins."""
 
-    adaptive_allowed: ClassVar[bool] = False
+    adaptable: ClassVar[bool] = False
 
     bin_count: int = attrs.field()
     log_min: float
@@ -747,10 +723,9 @@ def pretty_binning(
     range: RangeTuple | None = None,
     min_bin_width: float | None = None,
     max_bin_width: float | None = None,
-    adaptive: bool = False,
     includes_right_edge: bool = False,
 ) -> FixedWidthBinning:
-    """Construct fixed-width ninning schema with bins automatically optimized to human-friendly widths.
+    """Construct fixed-width binning schema with bins automatically optimized to human-friendly widths.
 
     Typical widths are: 1.0, 25,0, 0.02, 500, 2.5e-7, ...
 
@@ -788,7 +763,6 @@ def pretty_binning(
         data=data,
         range=range,
         align=True,
-        adaptive=adaptive,
         includes_right_edge=includes_right_edge,
     )
 
@@ -859,7 +833,6 @@ def static_binning(
 def integer_binning(
     data: np.ndarray | None = None,
     *,
-    adaptive: bool = False,
     range: tuple[int, int] | None = None,
     bin_width: int = 1,
 ) -> FixedWidthBinning:
@@ -874,7 +847,7 @@ def integer_binning(
     if range:
         kwargs["range"] = tuple(r - 0.5 for r in range)
     else:
-        kwargs["bin_shift"] = 0.5
+        kwargs["shift"] = 0.5
     return fixed_width_binning(data=data, bin_width=bin_width, align=False, **kwargs)
 
 
@@ -885,7 +858,6 @@ def fixed_width_binning(
     *,
     min_: float | None = None,
     bin_count: int | None = None,
-    adaptive: bool = False,
     range: RangeTuple | None = None,
     align: bool | None = None,
     includes_right_edge: bool = False,
@@ -919,8 +891,6 @@ def fixed_width_binning(
             if align is None:
                 # We should respect the lower bound of the range
                 align = False
-            if adaptive:
-                raise ValueError("Cannot set `adaptive` when `range` is set.")
             align = False
             min_ = range[0]
             max_ = range[1]
@@ -936,7 +906,6 @@ def fixed_width_binning(
     return FixedWidthBinning(
         bin_width=bin_width,
         includes_right_edge=includes_right_edge,
-        adaptive=adaptive,
     )
 
 

--- a/src/physt/binnings.py
+++ b/src/physt/binnings.py
@@ -175,7 +175,7 @@ class BinningBase(ABC):
         if np.array_equal(self.bins, other.bins):
             return self, None, None
         if is_bin_subset(other.bins, self.bins):
-            indices = np.searchsorted(other.bins[:, 0], self.bins[:, 0])
+            indices = np.searchsorted(self.bins[:, 0], other.bins[:, 0])
             return self, None, list(enumerate(indices))
 
         # Otherwise, the subclass needs to implement it

--- a/src/physt/binnings.py
+++ b/src/physt/binnings.py
@@ -159,6 +159,7 @@ class BinningBase(ABC):
 
         Returns
         -------
+        binning: New binning that fits all values
         bin_map: BinMap or None or int
             None => There was no change in bins
             int => The bins are only shifted (allows mass assignment)
@@ -167,31 +168,25 @@ class BinningBase(ABC):
         """
         raise NotImplementedError()
 
-    @final
-    def adapt(self, other: "BinningBase") -> tuple[BinMap | None, BinMap | None]:
-        """Adapt this binning so that it contains all bins of another binning.
+    def coerce(
+        self, other: "BinningBase"
+    ) -> tuple["BinningBase", BinMap | None, BinMap | None]:
+        """..."""
 
-        Parameters
-        ----------
-        other: BinningBase
-
-        Returns
-        -------
-        map1: A remapping from old bins to new bins. If not changed, None.
-        map2: A remapping of `other` bins to new bins. If not changed, None.
-
-        Note
-        ----
-        Implement the `_adapt` template method.
-        """
+        # Two trivial situation with which we can deal here
         if np.array_equal(self.bins, other.bins):
-            # Already adapted
-            return None, None
-        return self._adapt(other)
+            return self, None, None
+        if is_bin_subset(other.bins, self.bins):
+            indices = np.searchsorted(other.bins[:, 0], self.bins[:, 0])
+            return self, None, list(enumerate(indices))
 
-    def _adapt(self, other: "BinningBase") -> tuple[BinMap | None, BinMap | None]:
-        # Implement this if appropriate. It cannot be an abstract method.
-        raise RuntimeError(f"Cannot adapt {self.__class__.__name__}.")
+        # Otherwise, the subclass needs to implement it
+        return self._coerce(other)
+
+    def _coerce(
+        self, other: "BinningBase"
+    ) -> tuple["BinningBase", BinMap | None, BinMap | None]:
+        raise NotImplementedError()
 
     def __eq__(self, other: object) -> bool:
         if self is other:
@@ -431,7 +426,7 @@ class FixedWidthBinning(EdgeBasedBinning):
     adaptable: ClassVar[bool] = True
 
     bin_count: int = attrs.field(default=0)
-    bin_width: float = attrs.field(default=1.0, converter=float)
+    bin_width: float = attrs.field(converter=float)
     times_min: int | None = attrs.field(default=None)
     shift: float = 0.0
 
@@ -492,63 +487,58 @@ class FixedWidthBinning(EdgeBasedBinning):
     def is_regular(self, **kwargs) -> bool:
         return True
 
-    def _force_bin_existence_single(
-        self, value: float, *, includes_right_edge: bool | None = None
-    ) -> tuple["FixedWidthBinning", int | None]:
-        if includes_right_edge is None:
-            includes_right_edge = self.includes_right_edge
+    def _extended_bins_to_adapt(
+        self, values: ArrayLike
+    ) -> tuple[int | None, int | None]:
+        """Find how many bins to add to both sides to cover `values`."""
+        if np.isscalar(values):
+            return self._extended_bins_to_adapt_single(cast(float, values))
+        array = np.asanyarray(values, copy=False)
+        add_left, _ = self._extended_bins_to_adapt_single(array.min())
+        _, add_right = self._extended_bins_to_adapt_single(array.max())
+        return add_left, add_right
 
-        if self._bin_count == 0:
-            self._times_min = int(np.floor((value - self._shift) / self.bin_width))
-            self._bin_count = 1
-            # No bins yet, no remapping needed
-            return 0
-        else:
-            add_left = add_right = 0
-            if value < self.numpy_bins[0]:
-                add_left = int(np.ceil((self.numpy_bins[0] - value) / self.bin_width))
-                self._times_min -= add_left  # type: ignore  # We know it is not None
-                self._bin_count += add_left
-            elif value >= self.numpy_bins[-1]:
-                add_right = (value - self.numpy_bins[-1]) / self.bin_width
-                add_right = int(np.ceil(add_right))
-                self._bin_count += add_right
-                if self.last_edge == value and not includes_right_edge:
-                    add_right += 1
-                    self._bin_count += 1
-            if add_left or add_right:
-                return add_left
-            else:
-                return None
+    def _extended_bins_to_adapt_single(
+        self, value: float
+    ) -> tuple[int | None, int | None]:
+        if value < self.numpy_bins[0]:
+            add_left = int(np.ceil((self.numpy_bins[0] - value) / self.bin_width))
+            return add_left, None
+        if value > self.numpy_bins[-1]:
+            add_right = int(np.ceil((value - self.numpy_bins[-1]) / self.bin_width))
+            return add_right, None
+        if value == self.numpy_bins[-1]:
+            return 1, None
+        return None, None
 
     def force_bin_existence(
-        self, values: ArrayLike, *, includes_right_edge=None
-    ) -> tuple[FixedWidthBinning, int | BinMap | None]:
-        if np.isscalar(values):
-            return self._force_bin_existence_single(
-                cast(float, values), includes_right_edge=includes_right_edge
+        self, values: ArrayLike
+    ) -> tuple["BinningBase", int | None]:
+        if self.bin_count == 0:
+            if self.shift:
+                # TODO: Do this
+                raise NotImplementedError("A hístogram with shift and ")
+            return fixed_width_binning(values, bin_width=self.bin_width)
+        add_left, add_right = self._extended_bins_to_adapt(values)
+        if add_right and self.includes_right_edge:
+            raise ValueError(
+                "Cannot extend to the right if the last bin includes the right edge."
             )
-        else:
-            arr = np.asarray(values)
-            min_, max_ = arr.min(), arr.max()
-            result = self._force_bin_existence_single(min_)
-            result2 = self._force_bin_existence_single(
-                max_, includes_right_edge=includes_right_edge
-            )
-            if result is None:
-                return result2
-            else:
-                return result
+        if not add_left and not add_right:
+            # Nothing changes
+            return self, None
+        # We only shift (potentially by 0)
+        return self, add_left
 
     @property
     def first_edge(self) -> float:
-        return self._bin_width * self._validate_times_min() + self._shift
+        return self.bin_width * self._validate_times_min() + self.shift
 
     @property
     def last_edge(self) -> float:
         return (
-            self._validate_times_min() + self._bin_count
-        ) * self._bin_width + self._shift
+            self._validate_times_min() + self.bin_count
+        ) * self.bin_width + self.shift
 
     @property
     # TODO: Cache this
@@ -567,54 +557,39 @@ class FixedWidthBinning(EdgeBasedBinning):
             )
         return self.times_min
 
-    def _force_new_min_max(self, new_min, new_max) -> BinMap | None:
-        bin_map = None
-        add_right = add_left = 0
-        times_min = self._validate_times_min()
-        if new_min < times_min:  # type: ignore
-            add_left = times_min - new_min
-        if new_max - times_min > self._bin_count:  # type: ignore
-            add_right = new_max - times_min - self._bin_count
-        if add_left or add_right:
-            bin_map = ((i, i + add_left) for i in range(self._bin_count))
-            self._set_min_and_count(
-                times_min - add_left, self._bin_count + add_left + add_right
-            )
-        return bin_map
-
-    def _set_min_and_count(self, times_min: int | None, bin_count: int) -> None:
-        self._bin_count = bin_count
-        self._times_min = times_min
-
-    def _adapt(self, other: BinningBase) -> tuple[BinMap | None, BinMap | None]:
+    def _coerce(
+        self, other: BinningBase
+    ) -> tuple[BinningBase, BinMap | int | None, BinMap | int | None]:
         other = other.as_fixed_width()
         if self.bin_width != other.bin_width:
             raise ValueError(
-                "Cannot adapt fixed-width histograms with different widths"
+                f"Cannot adapt fixed-width histograms with different bin widths: {self.bin_width} vs {other.bin_width}."
             )
-        if self._shift != other._shift:
+        if self.shift != other.shift:
             raise ValueError(
-                f"Cannot adapt shifted fixed-width histograms: {self._shift} vs {other._shift}"
+                f"Cannot adapt shifted fixed-width histograms: {self.shift} vs {other.shift}"
             )
-        # Following operations modify schemas
-        other = other.copy()
-        if other.bin_count == 0:
-            return None, ()
+
+        # Trivial cases
         if self.bin_count == 0:
-            self._set_min_and_count(other._times_min, other.bin_count)
-            return (), None
+            return other, None, None
+        if other.bin_count == 0:
+            return self, None, None
 
-        times_min = self._validate_times_min()
-        other_times_min = other._validate_times_min()
-
-        new_min: float = min(times_min, other_times_min)
-        new_max: float = max(
-            times_min + self._bin_count, other_times_min + other._bin_count
+        new_times_min = min(self.times_min, other.times_min)
+        new_times_max = max(
+            self.times_min + self.bin_count, other.times_min + other.bin_count
+        )
+        result = FixedWidthBinning(
+            bin_width=self.bin_width,
+            times_min=new_times_min,
+            bin_count=new_times_max - new_times_min,
+            shift=self.shift,
         )
 
-        bin_map1 = self._force_new_min_max(new_min, new_max)
-        bin_map2 = other._force_new_min_max(new_min, new_max)
-        return bin_map1, bin_map2
+        bin_map1 = self.times_min - new_times_min
+        bin_map2 = other.times_min - new_times_min
+        return result, bin_map1, bin_map2
 
     def as_fixed_width(self, *, copy: bool = True) -> "FixedWidthBinning":
         if copy:
@@ -858,10 +833,10 @@ def fixed_width_binning(
     data: np.ndarray | None = None,
     bin_width: float = 1.0,
     *,
-    min_: float | None = None,
     bin_count: int | None = None,
     range: RangeTuple | None = None,
     align: bool | None = None,
+    shift: float | None = None,
     includes_right_edge: bool = False,
 ) -> FixedWidthBinning:
     """Construct fixed-width binning schema.
@@ -870,7 +845,9 @@ def fixed_width_binning(
     ----------
     bin_width: float
     range: (min, max)
-    align: Must be multiple of bin_width
+    align: all edges must align with multiples of the bin_width
+        i.e. we cannot have [47, 49, 51] for bin_width=2
+    shift:
     """
     if data is not None or range:
         # First try to create from limits
@@ -902,12 +879,14 @@ def fixed_width_binning(
             max_=max_,
             bin_width=bin_width,
             align=align,
+            shift=shift,
             includes_right_edge=includes_right_edge,
         )
 
     return FixedWidthBinning(
         bin_width=bin_width,
         includes_right_edge=includes_right_edge,
+        shift=shift or 0.0,
     )
 
 

--- a/src/physt/binnings.py
+++ b/src/physt/binnings.py
@@ -88,19 +88,25 @@ class BinningBase(ABC):
     """Whether the right edge of the last bin is included in the binning."""
 
     @overload
-    def __getitem__(self, index: slice) -> StaticBinning: ...
+    def __getitem__(self, index: slice | np.ndarray) -> StaticBinning: ...
 
     @overload
     def __getitem__(self, index: int) -> EdgePair: ...
 
-    def __getitem__(self, index: slice | int) -> StaticBinning | EdgePair:
-        if isinstance(index, slice):
-            same_right_edge = self.bins[index][-1, 1] == self.bins[-1, 1]
-            return StaticBinning(
-                bins=self.bins[index],
-                includes_right_edge=same_right_edge and self.includes_right_edge,
-            )
-        return self.bins[index]
+    def __getitem__(self, index: slice | np.ndarray | int) -> StaticBinning | EdgePair:
+        if isinstance(index, int):
+            return self.bins[index]
+        if isinstance(index, np.ndarray):
+            if index.dtype == bool:
+                if index.shape != (self.bin_count,):
+                    raise IndexError(
+                        "Cannot index with masked array of a wrong dimension"
+                    )
+        same_right_edge = self.bins[index][-1, 1] == self.bins[-1, 1]
+        return StaticBinning(
+            bins=self.bins[index],
+            includes_right_edge=same_right_edge and self.includes_right_edge,
+        )
 
     @staticmethod
     def from_dict(a_dict: dict[str, Any]) -> BinningBase:
@@ -168,8 +174,22 @@ class BinningBase(ABC):
 
     def coerce(
         self, other: "BinningBase"
-    ) -> tuple["BinningBase", BinMap | None, BinMap | None]:
-        """..."""
+    ) -> tuple["BinningBase", BinMap | int | None, BinMap | int | None]:
+        """Find a binning that is a superset of both self and `other`.
+
+        Parameters
+        ----------
+        values: All values we want bins for.
+
+        Returns
+        -------
+        binning: New binning that satisfies
+        bin_map: BinMap or None or int
+            None => There was no change in bins
+            int => The bins are only shifted (allows mass assignment)
+            otherwise => the iterable contains tuples (old bin index, new bin index)
+                new bin index can occur multiple times, which corresponds to bin merging
+        """
 
         # Two trivial situation with which we can deal here
         if np.array_equal(self.bins, other.bins):
@@ -183,7 +203,7 @@ class BinningBase(ABC):
 
     def _coerce(
         self, other: "BinningBase"
-    ) -> tuple["BinningBase", BinMap | None, BinMap | None]:
+    ) -> tuple["BinningBase", BinMap | int | None, BinMap | int | None]:
         raise NotImplementedError()
 
     @property
@@ -254,8 +274,6 @@ class BinningBase(ABC):
         StaticBinning
             A new static binning with a copy of bins.
         """
-        if not copy:
-            return self
         return StaticBinning(
             bins=self.bins.copy(), includes_right_edge=self.includes_right_edge
         )
@@ -270,6 +288,12 @@ class BinningBase(ABC):
         if self.bin_count == 0:
             raise ValueError("Cannot guess binning width with zero bins")
         elif self.bin_count == 1 or self.is_consecutive() and self.is_regular():
+            return FixedWidthBinning.create_from_min_max(
+                min_=self.bins[0, 0],
+                max_=self.bins[-1, 1],
+                align=False,
+                bin_count=self.bin_count,
+            )
             return FixedWidthBinning(
                 min=self.bins[0, 0],
                 bin_count=self.bin_count,
@@ -447,21 +471,32 @@ class FixedWidthBinning(EdgeBasedBinning):
         *,
         min_: float,
         max_: float,
-        bin_width: float,
+        bin_width: float | None = None,
+        bin_count: int | None = None,
         includes_right_edge: bool = False,
         align: bool = True,
         shift: float | None = None,
     ) -> "FixedWidthBinning":
         if align and shift:
             raise ValueError("Cannot align with shift.")
+        if bin_width and bin_count:
+            raise ValueError("Cannot specify both bin_width and bin_count.")
+        if not bin_width and not bin_count:
+            raise ValueError("Must specify either bin_width or bin_count.")
+        if not bin_width:
+            assert bin_count is not None
+            bin_width = (max_ - min_) / bin_count
         times_min = int(np.floor((min_ - (shift or 0.0)) / bin_width))
         if shift is None:
             shift = 0.0 if align else min_ - times_min * bin_width
-        bin_count = int(np.ceil((max_ - (times_min * bin_width + shift)) / bin_width))
-        if not includes_right_edge and shift + bin_count * bin_width == max_:
-            bin_count += 1
-        # If min == max, we might end up with 0 bins by now...
-        bin_count = max(1, bin_count)
+        if not bin_count:
+            bin_count = int(
+                np.ceil((max_ - (times_min * bin_width + shift)) / bin_width)
+            )
+            if not includes_right_edge and shift + bin_count * bin_width == max_:
+                bin_count += 1
+            # If min == max, we might end up with 0 bins by now...
+            bin_count = max(1, bin_count)
         return cls(
             bin_width=bin_width,
             bin_count=bin_count,
@@ -519,18 +554,18 @@ class FixedWidthBinning(EdgeBasedBinning):
         new_binning = attrs.evolve(
             self,
             bin_count=self.bin_count + add_left + add_right,
-            bin_times_min=self.bin_times_min - add_left,
+            bin_times_min=self._unwrap_times_min() - add_left,
         )
         return new_binning, add_left
 
     @property
     def first_edge(self) -> float:
-        return self.bin_width * self._validate_times_min() + self.bin_shift
+        return self.bin_width * self._unwrap_times_min() + self.bin_shift
 
     @property
     def last_edge(self) -> float:
         return (
-            self._validate_times_min() + self.bin_count
+            self._unwrap_times_min() + self.bin_count
         ) * self.bin_width + self.bin_shift
 
     @property
@@ -539,10 +574,10 @@ class FixedWidthBinning(EdgeBasedBinning):
         if not self.bin_count:
             return np.zeros((0, 2), dtype=float)
         return (
-            self._validate_times_min() + np.arange(self.bin_count + 1, dtype=int)
+            self._unwrap_times_min() + np.arange(self.bin_count + 1, dtype=int)
         ) * self.bin_width + self.bin_shift
 
-    def _validate_times_min(self) -> int:
+    def _unwrap_times_min(self) -> int:
         """Check the binning is well-defined and return the times min."""
         if self.bin_times_min is None:
             raise ValueError(
@@ -569,9 +604,12 @@ class FixedWidthBinning(EdgeBasedBinning):
         if other.bin_count == 0:
             return self, None, None
 
-        new_times_min = min(self.bin_times_min, other.bin_times_min)
+        # Type-checker-safe min and max computation
+        self_times_min = self._unwrap_times_min()
+        other_times_min = other._unwrap_times_min()
+        new_times_min = min(self_times_min, other_times_min)
         new_times_max = max(
-            self.bin_times_min + self.bin_count, other.bin_times_min + other.bin_count
+            self_times_min + self.bin_count, other_times_min + other.bin_count
         )
         result = FixedWidthBinning(
             bin_width=self.bin_width,
@@ -580,8 +618,9 @@ class FixedWidthBinning(EdgeBasedBinning):
             bin_shift=self.bin_shift,
         )
 
-        bin_map1 = self.bin_times_min - new_times_min
-        bin_map2 = other.bin_times_min - new_times_min
+        # Both as plain numbers
+        bin_map1 = self_times_min - new_times_min
+        bin_map2 = other_times_min - new_times_min
         return result, bin_map1, bin_map2
 
     def as_fixed_width(self, *, copy: bool = True) -> "FixedWidthBinning":
@@ -845,12 +884,12 @@ def fixed_width_binning(
         i.e. we cannot have [47, 49, 51] for bin_width=2
     """
     if data is not None or range:
+        if bin_count is not None:
+            raise ValueError("Cannot set both `bin_count` and `data`/`range`.")
+
         # First try to create from limits
         min_ = None
         max_ = None
-
-        if bin_count is not None:
-            raise ValueError("Cannot set both `bin_count` and `data`/`range`.")
 
         if data is not None:
             arr = np.asarray(data)
@@ -858,6 +897,7 @@ def fixed_width_binning(
             max_ = np.max(arr)
             if align is None:
                 align = True
+
         if range:
             # This takes precedence over data
             if align is None:
@@ -865,6 +905,11 @@ def fixed_width_binning(
                 align = False
             min_ = range[0]
             max_ = range[1]
+
+        # Type-checker
+        assert min_ is not None
+        assert max_ is not None
+        assert align is not None
 
         return FixedWidthBinning.create_from_min_max(
             min_=min_,

--- a/src/physt/binnings.py
+++ b/src/physt/binnings.py
@@ -875,9 +875,7 @@ def integer_binning(
         kwargs["range"] = tuple(r - 0.5 for r in range)
     else:
         kwargs["bin_shift"] = 0.5
-    return fixed_width_binning(
-        data=data, bin_width=bin_width, align=False, adaptive=adaptive, **kwargs
-    )
+    return fixed_width_binning(data=data, bin_width=bin_width, align=False, **kwargs)
 
 
 @register_binning()

--- a/src/physt/binnings.py
+++ b/src/physt/binnings.py
@@ -186,15 +186,6 @@ class BinningBase(ABC):
     ) -> tuple["BinningBase", BinMap | None, BinMap | None]:
         raise NotImplementedError()
 
-    def __eq__(self, other: object) -> bool:
-        if self is other:
-            return True
-        if type(other) is not type(self):
-            return False
-        if (bins := self.bins) is not None:
-            return np.array_equal(bins, other.bins)
-        return False
-
     @property
     @abstractmethod
     def bin_count(self) -> int:
@@ -406,7 +397,9 @@ class EdgeBasedBinning(BinningBase, ABC):
 class NumpyBinning(EdgeBasedBinning):
     """Binning schema working as numpy.histogram."""
 
-    numpy_bins: np.ndarray = attrs.field(converter=np.asarray)
+    numpy_bins: np.ndarray = attrs.field(
+        converter=np.asarray, eq=attrs.cmp_using(np.array_equal)
+    )
 
     @numpy_bins.validator
     def _validate_rising_bins(self, attribute, value):

--- a/src/physt/binnings.py
+++ b/src/physt/binnings.py
@@ -146,12 +146,10 @@ class BinningBase(ABC):
             return is_consecutive(self.bins, rtol=rtol, atol=atol)
         return True
 
-    def force_bin_existence(
+    def coerce_values(
         self, values: ArrayLike
     ) -> tuple["BinningBase", int | BinMap | None]:
         """Change schema so that there is a bin for value.
-
-        It is necessary to implement the _force_bin_existence template method.
 
         Parameters
         ----------
@@ -511,14 +509,12 @@ class FixedWidthBinning(EdgeBasedBinning):
             return 1, None
         return None, None
 
-    def force_bin_existence(
-        self, values: ArrayLike
-    ) -> tuple["BinningBase", int | None]:
+    def coerce_values(self, values: ArrayLike) -> tuple["BinningBase", int | None]:
         if self.bin_count == 0:
             if self.shift:
-                # TODO: Do this
-                raise NotImplementedError("A hístogram with shift and ")
-            return fixed_width_binning(values, bin_width=self.bin_width)
+                # TODO: Implement this
+                raise NotImplementedError()
+            return fixed_width_binning(values, bin_width=self.bin_width), None
         add_left, add_right = self._extended_bins_to_adapt(values)
         if add_right and self.includes_right_edge:
             raise ValueError(

--- a/src/physt/binnings.py
+++ b/src/physt/binnings.py
@@ -468,7 +468,9 @@ class FixedWidthBinning(EdgeBasedBinning):
             raise ValueError("Cannot align with shift.")
         times_min = int(np.floor(min_ - (shift or 0.0) / bin_width))
         shift = 0 if align else min_ - times_min * bin_width
-        bin_count = max(1, int(np.floor(max_ - (times_min * bin_width + shift))))
+        bin_count = max(
+            1, int(np.ceil((max_ - (times_min * bin_width + shift)) / bin_width))
+        )
         if includes_right_edge and shift + bin_count * bin_width == max_:
             bin_count += 1
         return cls(

--- a/src/physt/binnings.py
+++ b/src/physt/binnings.py
@@ -459,8 +459,9 @@ class FixedWidthBinning(EdgeBasedBinning):
     ) -> "FixedWidthBinning":
         if align and shift:
             raise ValueError("Cannot align with shift.")
-        times_min = int(np.floor(min_ - (shift or 0.0) / bin_width))
-        shift = 0 if align else min_ - times_min * bin_width
+        times_min = int(np.floor((min_ - (shift or 0.0)) / bin_width))
+        if shift is None:
+            shift = 0 if align else min_ - times_min * bin_width
         bin_count = max(
             1, int(np.ceil((max_ - (times_min * bin_width + shift)) / bin_width))
         )

--- a/src/physt/binnings.py
+++ b/src/physt/binnings.py
@@ -479,9 +479,7 @@ class FixedWidthBinning(EdgeBasedBinning):
     def is_regular(self, **kwargs) -> bool:
         return True
 
-    def _extended_bins_to_adapt(
-        self, values: ArrayLike
-    ) -> tuple[int | None, int | None]:
+    def _extended_bins_to_adapt(self, values: ArrayLike) -> tuple[int, int]:
         """Find how many bins to add to both sides to cover `values`."""
         if np.isscalar(values):
             return self._extended_bins_to_adapt_single(cast(float, values))
@@ -490,18 +488,16 @@ class FixedWidthBinning(EdgeBasedBinning):
         _, add_right = self._extended_bins_to_adapt_single(array.max())
         return add_left, add_right
 
-    def _extended_bins_to_adapt_single(
-        self, value: float
-    ) -> tuple[int | None, int | None]:
+    def _extended_bins_to_adapt_single(self, value: float) -> tuple[int, int]:
         if value < self.numpy_bins[0]:
             add_left = int(np.ceil((self.numpy_bins[0] - value) / self.bin_width))
-            return add_left, None
+            return add_left, 0
         if value > self.numpy_bins[-1]:
             add_right = int(np.ceil((value - self.numpy_bins[-1]) / self.bin_width))
-            return add_right, None
+            return 0, add_right
         if value == self.numpy_bins[-1]:
-            return 1, None
-        return None, None
+            return 0, 1
+        return 0, 0
 
     def coerce_values(self, values: ArrayLike) -> tuple["BinningBase", int | None]:
         if self.bin_count == 0:
@@ -518,7 +514,12 @@ class FixedWidthBinning(EdgeBasedBinning):
             # Nothing changes
             return self, None
         # We only shift (potentially by 0)
-        return self, add_left
+        new_binning = attrs.evolve(
+            self,
+            bin_count=self.bin_count + add_left + add_right,
+            times_min=self.times_min - add_left,
+        )
+        return new_binning, add_left
 
     @property
     def first_edge(self) -> float:

--- a/src/physt/binnings.py
+++ b/src/physt/binnings.py
@@ -843,7 +843,6 @@ def fixed_width_binning(
     range: (min, max)
     align: all edges must align with multiples of the bin_width
         i.e. we cannot have [47, 49, 51] for bin_width=2
-    shift:
     """
     if data is not None or range:
         # First try to create from limits
@@ -861,12 +860,9 @@ def fixed_width_binning(
                 align = True
         if range:
             # This takes precedence over data
-            if align:
-                raise ValueError("Cannot set both `align` and `range`.")
             if align is None:
                 # We should respect the lower bound of the range
                 align = False
-            align = False
             min_ = range[0]
             max_ = range[1]
 

--- a/src/physt/compat/geant4.py
+++ b/src/physt/compat/geant4.py
@@ -3,7 +3,7 @@
 See https://geant4.web.cern.ch/ for the project pages.
 """
 
-import codecs
+from pathlib import Path
 
 import numpy as np
 
@@ -12,7 +12,7 @@ from physt.statistics import Statistics
 from physt.types import Histogram1D, Histogram2D
 
 
-def load_csv(path: str) -> Histogram1D | Histogram2D:
+def load_csv(path: str | Path) -> Histogram1D | Histogram2D:
     """Loads a histogram as output from Geant4 analysis tools in CSV format.
 
     Parameters
@@ -26,7 +26,7 @@ def load_csv(path: str) -> Histogram1D | Histogram2D:
     """
     meta = []
     data_raw = []
-    with codecs.open(path, encoding="ASCII") as in_file:
+    with Path(path).open("r", encoding="ASCII") as in_file:
         for line in in_file:
             if line.startswith("#"):
                 key, value = line[1:].strip().split(" ", 1)
@@ -59,7 +59,9 @@ def _create_h1(data, meta) -> Histogram1D:
     min_ = float(min_)
     max_ = float(max_)
     binning = fixed_width_binning(
-        bin_width=(max_ - min_) / bin_count, range=(min_, max_)
+        bin_width=(max_ - min_) / bin_count,
+        range=(min_, max_),
+        includes_right_edge=True,
     )
     stats = Statistics(sum=data[1:-1, 3].sum(), sum2=data[1:-1, 4].sum())
 
@@ -84,7 +86,9 @@ def _create_h2(data, meta) -> Histogram2D:
         min_ = float(min_)
         max_ = float(max_)
         binning = fixed_width_binning(
-            bin_width=(max_ - min_) / bin_count, range=(min_, max_)
+            bin_width=(max_ - min_) / bin_count,
+            range=(min_, max_),
+            includes_right_edge=True,
         )
         binnings.append(binning)
 

--- a/src/physt/histogram1d.py
+++ b/src/physt/histogram1d.py
@@ -367,8 +367,9 @@ class Histogram1D(ObjectWithBinning, HistogramBase):
         """
         self._coerce_dtype(type(weight))
         if self.is_adaptive:
-            bin_map = self._binning.force_bin_existence(value)
-            self._reshape_data(self._binning.bin_count, bin_map)
+            binning, bin_map = self._binning.coerce_values(value)
+            self._change_binning(binning, bin_map, 0)
+            # self._reshape_data(self._binning.bin_count, bin_map)
 
         ixbin = self.find_bin(value)
         if ixbin is None:
@@ -408,8 +409,8 @@ class Histogram1D(ObjectWithBinning, HistogramBase):
         values_array, array_mask = extract_1d_array(values, dropna=dropna)
         assert values_array is not None
         if self.is_adaptive:
-            bin_map = self._binning.force_bin_existence(values_array)
-            self._reshape_data(self._binning.bin_count, bin_map)
+            binning, bin_map = self._binning.coerce_values(values_array)
+            self._change_binning(binning, bin_map, 0)
         weights_array = extract_weights(weights, array_mask=array_mask)
         if weights_array is not None:
             self._coerce_dtype(weights_array.dtype)

--- a/src/physt/histogram1d.py
+++ b/src/physt/histogram1d.py
@@ -408,8 +408,8 @@ class Histogram1D(ObjectWithBinning, HistogramBase):
         values_array, array_mask = extract_1d_array(values, dropna=dropna)
         assert values_array is not None
         if self.is_adaptive:
-            map = self._binning.force_bin_existence(values_array)
-            self._reshape_data(self._binning.bin_count, map)
+            bin_map = self._binning.force_bin_existence(values_array)
+            self._reshape_data(self._binning.bin_count, bin_map)
         weights_array = extract_weights(weights, array_mask=array_mask)
         if weights_array is not None:
             self._coerce_dtype(weights_array.dtype)

--- a/src/physt/histogram1d.py
+++ b/src/physt/histogram1d.py
@@ -366,7 +366,7 @@ class Histogram1D(ObjectWithBinning, HistogramBase):
         Note: Name was selected because of the eponymous method in ROOT
         """
         self._coerce_dtype(type(weight))
-        if self._binning.is_adaptive():
+        if self.is_adaptive:
             bin_map = self._binning.force_bin_existence(value)
             self._reshape_data(self._binning.bin_count, bin_map)
 
@@ -407,7 +407,7 @@ class Histogram1D(ObjectWithBinning, HistogramBase):
         # TODO: Unify with HistogramBase
         values_array, array_mask = extract_1d_array(values, dropna=dropna)
         assert values_array is not None
-        if self._binning.is_adaptive():
+        if self.is_adaptive:
             map = self._binning.force_bin_existence(values_array)
             self._reshape_data(self._binning.bin_count, map)
         weights_array = extract_weights(weights, array_mask=array_mask)

--- a/src/physt/histogram1d.py
+++ b/src/physt/histogram1d.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import dataclasses
 import warnings
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, overload
 
 import numpy as np
 
@@ -212,6 +212,12 @@ class Histogram1D(ObjectWithBinning, HistogramBase):
         else:
             raise ValueError("In Histogram1D.select(), axis must be 0.")
 
+    @overload
+    def __getitem__(self, index: slice | np.ndarray) -> "Histogram1D": ...
+
+    @overload
+    def __getitem__(self, index: int) -> tuple[np.ndarray, float]: ...
+
     def __getitem__(
         self, index: int | slice | np.ndarray
     ) -> "Histogram1D" | tuple[np.ndarray, float]:
@@ -231,6 +237,7 @@ class Histogram1D(ObjectWithBinning, HistogramBase):
         underflow = np.nan
         overflow = np.nan
         keep_missed = False
+
         if isinstance(index, int):
             return self.bins[index], self.frequencies[index]
         if isinstance(index, np.ndarray):
@@ -251,9 +258,12 @@ class Histogram1D(ObjectWithBinning, HistogramBase):
                     underflow += self.frequencies[0 : index.start].sum()
                 if index.stop:
                     overflow += self.frequencies[index.stop :].sum()
+
         # Masked arrays or item list or ...
+        binning = self._binning.as_static(copy=False)
+
         return self.__class__(
-            self._binning.as_static(copy=False)[index],
+            binning[index],
             self.frequencies[index],
             self.errors2[index],
             overflow=overflow,

--- a/src/physt/histogram_base.py
+++ b/src/physt/histogram_base.py
@@ -590,14 +590,14 @@ class HistogramBase(abc.ABC):
     ):
         """Fill new data arrays using a map.
 
-        It modifies new_frequencies and new_errors2 in-place.
+        Note: It modifies new_frequencies and new_errors2 in-place!
 
         Parameters
         ----------
         old_frequencies : Source of frequencies data
-        new_frequencies : Target of frequencies data
+        new_frequencies : Target of frequencies data (updated)
         old_errors2 : Source of errors data
-        new_errors2 : Target of errors data
+        new_errors2 : Target of errors data (updated)
         bin_map: Iterable[(old, new)] or int or None
             As in _reshape_data
         axis: On which axis to apply

--- a/src/physt/histogram_base.py
+++ b/src/physt/histogram_base.py
@@ -25,7 +25,6 @@ if TYPE_CHECKING:
 
     HistogramType = TypeVar("HistogramType", bound="HistogramBase")
 
-
 # Various platforms have different default floating point dtypes.
 _FREQUENCY_SUPPORTED_DTYPES: list[type[np.number]] = [
     np.int16,
@@ -562,7 +561,7 @@ class HistogramBase(abc.ABC):
             If iterable, pairs specify which old bin should go into which new bin
         axis: On which axis to apply
         """
-        if bin_map is None:
+        if bin_map is None and new_size == self.shape[axis]:
             return
 
         new_shape = list(self.shape)
@@ -574,7 +573,7 @@ class HistogramBase(abc.ABC):
             new_frequencies=new_frequencies,
             old_errors2=self._errors2,
             new_errors2=new_errors2,
-            bin_map=bin_map,
+            bin_map=bin_map or 0,
             axis=axis,
         )
         self._frequencies = new_frequencies

--- a/src/physt/histogram_base.py
+++ b/src/physt/histogram_base.py
@@ -450,7 +450,7 @@ class HistogramBase(abc.ABC):
     def is_adaptive(self) -> bool:
         """Whether the binning can be changed with operations."""
         # TODO: remove in favour of adaptive property
-        return all(binning.is_adaptive() for binning in self._binnings)
+        return all(binning.adaptive for binning in self._binnings)
 
     def set_adaptive(self, value: bool = True):
         """Change the histogram binning to (non)adaptive.

--- a/src/physt/histogram_base.py
+++ b/src/physt/histogram_base.py
@@ -110,6 +110,7 @@ class HistogramBase(abc.ABC):
         axis_names: Iterable[str] | None = None,
         dtype: DTypeLike | None = None,
         keep_missed: bool = True,
+        adaptive: bool = False,
         **kwargs,
     ):
         """Constructor
@@ -153,6 +154,7 @@ class HistogramBase(abc.ABC):
                     )
             dtype = frequencies.dtype
             self.frequencies = frequencies
+        self.is_adaptive = adaptive
         self._dtype, _ = self._eval_dtype(dtype)  # type: ignore
 
         # Errors
@@ -172,6 +174,7 @@ class HistogramBase(abc.ABC):
     _frequencies: np.ndarray
     _errors2: np.ndarray
     _missed: np.ndarray
+    _adaptive: bool = False
 
     SUPPORTED_DTYPES: ClassVar[Collection[type[np.number]]] = tuple(
         _FREQUENCY_SUPPORTED_DTYPES
@@ -447,30 +450,21 @@ class HistogramBase(abc.ABC):
         """Total number (weight) of entries that missed the bins."""
         return self._missed.sum().item()
 
+    @property
     def is_adaptive(self) -> bool:
         """Whether the binning can be changed with operations."""
-        # TODO: remove in favour of adaptive property
-        return all(binning.adaptive for binning in self._binnings)
+        return self._adaptive
 
-    def set_adaptive(self, value: bool = True):
+    @is_adaptive.setter
+    def is_adaptive(self, value: bool = True):
         """Change the histogram binning to (non)adaptive.
 
         This requires binning in all dimensions to allow this.
         """
         # TODO: remove in favour of adaptive property
-        if not all(b.adaptive_allowed for b in self._binnings):
+        if not all(b.adaptive_allowed for b in self._binnings) and value:
             raise ValueError("All binnings must allow adaptive behaviour.")
-        for binning in self._binnings:
-            binning.set_adaptive(value)
-
-    @property
-    def adaptive(self) -> bool:
-        # TODO: Remove?
-        return self.is_adaptive()
-
-    @adaptive.setter
-    def adaptive(self, value: bool):
-        self.set_adaptive(value)
+        self._adaptive = value
 
     def _change_binning(
         self,
@@ -875,12 +869,12 @@ class HistogramBase(abc.ABC):
                 self.frequencies = self.frequencies + other.frequencies
                 self.errors2 = self.errors2 + other.errors2
                 self._missed += other._missed
-            elif self.is_adaptive():
+            elif self.is_adaptive:
                 if other.missed > 0:
                     raise ValueError("Cannot adapt histogram with missed values.")
 
                 other = other.copy()
-                other.set_adaptive(True)
+                other.is_adaptive = True
 
                 self._coerce_dtype(other.dtype)
 

--- a/src/physt/histogram_base.py
+++ b/src/physt/histogram_base.py
@@ -468,7 +468,7 @@ class HistogramBase(abc.ABC):
     def _change_binning(
         self,
         new_binning: BinningBase,
-        bin_map: BinMap | None,
+        bin_map: BinMap | int | None,
         axis: Axis = 0,
     ):
         """Set new binning and update the bin contents according to a map.

--- a/src/physt/histogram_base.py
+++ b/src/physt/histogram_base.py
@@ -659,6 +659,7 @@ class HistogramBase(abc.ABC):
         a_copy._meta_data = self._meta_data.copy()
         a_copy.keep_missed = self.keep_missed
         a_copy._missed = missed
+        a_copy.is_adaptive = self.is_adaptive
         return a_copy
 
     @abc.abstractmethod

--- a/src/physt/histogram_base.py
+++ b/src/physt/histogram_base.py
@@ -462,7 +462,7 @@ class HistogramBase(abc.ABC):
         This requires binning in all dimensions to allow this.
         """
         # TODO: remove in favour of adaptive property
-        if not all(b.adaptive_allowed for b in self._binnings) and value:
+        if not all(b.adaptable for b in self._binnings) and value:
             raise ValueError("All binnings must allow adaptive behaviour.")
         self._adaptive = value
 

--- a/src/physt/histogram_base.py
+++ b/src/physt/histogram_base.py
@@ -864,7 +864,6 @@ class HistogramBase(abc.ABC):
             if other.ndim != self.ndim:
                 raise ValueError("Cannot add histograms with different dimensions.")
             if self.has_same_bins(other):
-                # print("Has same!!!!!!!!!!")
                 self._coerce_dtype(other.dtype)
                 self.frequencies = self.frequencies + other.frequencies
                 self.errors2 = self.errors2 + other.errors2
@@ -875,15 +874,14 @@ class HistogramBase(abc.ABC):
 
                 other = other.copy()
                 other.is_adaptive = True
-
                 self._coerce_dtype(other.dtype)
 
                 for i in range(self.ndim):
-                    new_bins = self._binnings[i].copy()
-
-                    map1, map2 = new_bins.adapt(other._binnings[i])
-                    self._change_binning(new_bins, map1, axis=i)
-                    other._change_binning(new_bins, map2, axis=i)
+                    new_binning, map1, map2 = self._binnings[i].coerce(
+                        other._binnings[i]
+                    )
+                    self._change_binning(new_binning, map1, axis=i)
+                    other._change_binning(new_binning, map2, axis=i)
                 self.frequencies = self.frequencies + other.frequencies
                 self.errors2 = self.errors2 + other.errors2
             else:

--- a/src/physt/histogram_nd.py
+++ b/src/physt/histogram_nd.py
@@ -335,10 +335,10 @@ class HistogramND(HistogramBase):
     def fill(self, value: ArrayLike, weight: float = 1, **kwargs):
         self._coerce_dtype(type(weight))
         value_array = np.asarray(value)
-        for i, binning in enumerate(self._binnings):
-            if binning.is_adaptive():
-                bin_map = binning.force_bin_existence(value_array[i])
-                self._reshape_data(binning.bin_count, bin_map, i)
+        for axis, binning in enumerate(self._binnings):
+            if binning.adaptable:
+                binning, bin_map = binning.coerce_values(value_array[axis])
+                self._change_binning(binning, bin_map, axis)
         ixbin = self.find_bin(value_array, **kwargs)
         if ixbin is None and self.keep_missed:
             self._missed += weight
@@ -390,11 +390,9 @@ class HistogramND(HistogramBase):
             # TODO: Check for weights size?
             self._coerce_dtype(weights.dtype)
         for i, binning in enumerate(self._binnings):
-            if binning.is_adaptive():
-                bin_map = binning.force_bin_existence(
-                    values_array[:, i]
-                )  # TODO: Add to some test
-                self._reshape_data(binning.bin_count, bin_map, i)
+            if binning.adaptable:
+                new_binning, bin_map = binning.coerce_values(values_array[:, i])
+                self._change_binning(new_binning, bin_map, i)
         frequencies, errors2, missed = calculate_nd_frequencies(
             values_array, self._binnings, weights=weights
         )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,7 +21,7 @@ def create_adaptive():
             FixedWidthBinning(
                 bin_width=1,
                 bin_count=dim,
-                bin_times_min=0 if shape[i] else None,
+                times_min=0 if shape[i] else None,
                 adaptive=True,
             )
             for i, dim in enumerate(shape)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -30,8 +30,8 @@ def create_adaptive():
         if len(shape) == 2:
             klass = Histogram2D
         elif len(shape) == 1:
-            return Histogram1D(binning=binnings[0], frequencies=data)
-        return klass(binnings=binnings, frequencies=data)
+            return Histogram1D(binning=binnings[0], frequencies=data, adaptive=True)
+        return klass(binnings=binnings, frequencies=data, adaptive=True)
 
     return inner
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -22,7 +22,6 @@ def create_adaptive():
                 bin_width=1,
                 bin_count=dim,
                 times_min=0 if shape[i] else None,
-                adaptive=True,
             )
             for i, dim in enumerate(shape)
         ]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,7 +21,7 @@ def create_adaptive():
             FixedWidthBinning(
                 bin_width=1,
                 bin_count=dim,
-                times_min=0 if shape[i] else None,
+                bin_times_min=0 if shape[i] else None,
             )
             for i, dim in enumerate(shape)
         ]

--- a/tests/test_adaptive.py
+++ b/tests/test_adaptive.py
@@ -127,7 +127,7 @@ class TestAdaptiveND:
     def test_create_empty(self):
         h = histogramdd(None, "fixed_width", bin_width=10, dim=7, adaptive=True)
         assert h.ndim == 7
-        assert h.is_adaptive()
+        assert h.is_adaptive
 
     # TODO: Add a few more tests?
 

--- a/tests/test_adaptive.py
+++ b/tests/test_adaptive.py
@@ -144,16 +144,18 @@ class TestAdaptiveArithmetics:
         ha2 = h1(None, "fixed_width", bin_width=10, adaptive=True)
         ha2.fill_n([23, 51])
 
-        ha3 = ha1 + ha2
-        ha4 = ha2 + ha1
-        assert np.array_equal(ha3.frequencies, [1, 0, 2, 0, 1, 1])
-        assert np.array_equal(ha3.numpy_bins, [0, 10, 20, 30, 40, 50, 60])
-        assert ha4 == ha3
+        total1 = ha1 + ha2
+        total2 = ha2 + ha1
+        assert np.array_equal(total1.frequencies, [1, 0, 2, 0, 1, 1])
+        assert np.array_equal(total1.numpy_bins, [0, 10, 20, 30, 40, 50, 60])
+        assert total2 == total1
 
     def test_add_cross_2d(self):
         d1 = np.asarray([1, 21, 3])
         d2 = np.asarray([10, 12, 20])
-        h = h2(d1, d2, "fixed_width", bin_width=10, adaptive=True)
+
+        ha = h2(d1, d2, "fixed_width", bin_width=10, adaptive=True)
         hb = h2(d1, d2 + 10, "fixed_width", bin_width=10, adaptive=True)
-        hc = h + hb
-        assert np.array_equal(hc.numpy_bins[1], [10, 20, 30, 40])
+        total = ha + hb
+        assert np.array_equal(total.numpy_bins[0], [0, 10, 20, 30])
+        assert np.array_equal(total.numpy_bins[1], [10, 20, 30])

--- a/tests/test_adaptive.py
+++ b/tests/test_adaptive.py
@@ -99,8 +99,7 @@ class TestFillNAdaptive(object):
 class TestAdaptive2D(object):
     def test_create_empty(self):
         h = h2(None, None, "fixed_width", bin_width=10, adaptive=True)
-        for b in h._binnings:
-            assert b.is_adaptive()
+        assert h.is_adaptive
         assert h.ndim == 2
 
     def test_create_nonempty(self):

--- a/tests/test_binning.py
+++ b/tests/test_binning.py
@@ -69,7 +69,6 @@ class TestFixedWidthBins:
             assert m1 == 0
             assert m2 == 0
             assert np.array_equal(new.numpy_bins, [0, 10, 20, 30])
-            assert new.bin_count == 3
 
         def test_coerce_left(self, fixed_width_binning):
             other = binnings.FixedWidthBinning(
@@ -77,93 +76,63 @@ class TestFixedWidthBins:
                 bin_count=2,
                 times_min=-1,
             )
+            # Bins: [-10, 0, 10]
             new, m1, m2 = fixed_width_binning.coerce(other)
-            assert m1 == 1  # TODO: Validate the value
+            assert m1 == 1
             assert m2 == 0
-            assert new.bin_count == 3
+            assert np.array_equal(new.numpy_bins, [-10, 0, 10, 20])
 
-        def test_adapt_right(self):
-            b = binnings.FixedWidthBinning(
-                bin_width=10, bin_count=3, min=0, adaptive=True
+        def test_coerce_right(self, fixed_width_binning):
+            other = binnings.FixedWidthBinning(
+                bin_width=10,
+                bin_count=2,
+                times_min=1,
             )
-            b4 = binnings.FixedWidthBinning(
-                bin_width=10, bin_count=2, min=-30, adaptive=True
-            )
-            m1, m2 = b4.adapt(b)
-            assert tuple(m1) == ((0, 0), (1, 1))
-            assert tuple(m2) == ((0, 3), (1, 4), (2, 5))
-            assert b4.bin_count == 6
+            # Bins: [10, 20, 30]
+            new, m1, m2 = fixed_width_binning.coerce(other)
+            assert m1 == 0
+            assert m2 == 1
+            assert np.array_equal(new.numpy_bins, [0, 10, 20, 30])
 
-        def test_adapt_intersection1(self):
-            b = binnings.FixedWidthBinning(
-                bin_width=10, bin_count=3, min=0, adaptive=True
+        def test_coerce_nonadjacent(self, fixed_width_binning):
+            other = binnings.FixedWidthBinning(
+                bin_width=10,
+                bin_count=1,
+                times_min=3,
             )
-            b5 = binnings.FixedWidthBinning(
-                bin_width=10, bin_count=2, min=-10, adaptive=True
-            )
-            m1, m2 = b5.adapt(b)
-            assert tuple(m1) == ((0, 0), (1, 1))
-            assert tuple(m2) == ((0, 1), (1, 2), (2, 3))
-            assert b5.bin_count == 4
+            # Bins: [30, 40]
+            new, m1, m2 = fixed_width_binning.coerce(other)
+            assert m1 == 0
+            assert m2 == 3
+            assert np.array_equal(new.numpy_bins, [0, 10, 20, 30, 40])
 
-        def test_adapt_intersection2(self):
-            b = binnings.FixedWidthBinning(
-                bin_width=10, bin_count=3, min=0, adaptive=True
-            )
-            b6 = binnings.FixedWidthBinning(
-                bin_width=10, bin_count=3, min=10, adaptive=True
-            )
-            m1, m2 = b6.adapt(b)
-            assert tuple(m1) == ((0, 1), (1, 2), (2, 3))
-            assert tuple(m2) == ((0, 0), (1, 1), (2, 2))
-            assert b6.bin_count == 4
+        def test_coerce_subset(self, fixed_width_binning):
+            other = binnings.FixedWidthBinning(bin_width=10, bin_count=4, times_min=-1)
+            new1, m1, m2 = fixed_width_binning.coerce(other)
+            assert m1 == 1
+            assert m2 == 0
+            assert new1 == other
 
-        def test_adapt_internal(self):
-            b1 = binnings.FixedWidthBinning(
-                bin_width=10, bin_count=3, min=0, adaptive=True
-            )
+            # Try opposite way
+            new2, m1, m2 = other.coerce(fixed_width_binning)
+            assert new1 == new2
+
+        def test_coerce_invalid(self):
+            b1 = binnings.FixedWidthBinning(bin_width=10, bin_count=2, times_min=0)
             b2 = binnings.FixedWidthBinning(
-                bin_width=10, bin_count=1, min=10, adaptive=True
-            )
-            m1, m2 = b1.adapt(b2)
-            assert m1 is None
-            assert tuple(m2) == ((0, 1),)
-
-        def test_adapt_external(self):
-            b1 = binnings.FixedWidthBinning(
-                bin_width=10, bin_count=1, min=10, adaptive=True
-            )
-            b2 = binnings.FixedWidthBinning(
-                bin_width=10, bin_count=3, min=0, adaptive=True
-            )
-            m1, m2 = b1.adapt(b2)
-            assert tuple(m1) == ((0, 1),)
-            assert m2 is None
-            assert b1.bin_count == 3
-
-        def test_adapt_wrong(self):
-            b1 = binnings.FixedWidthBinning(
-                bin_width=10, bin_count=2, min=0, adaptive=True
-            )
-            b2 = binnings.FixedWidthBinning(
-                bin_width=10, bin_count=2, min=1, adaptive=True
+                bin_width=10, bin_count=2, times_min=0, shift=1
             )
             with pytest.raises(
-                ValueError, match="Cannot adapt shifted fixed-width histograms"
+                ValueError, match="Cannot coerce shifted fixed-width histograms"
             ):
-                b1.adapt(b2)
-            with pytest.raises(
-                ValueError, match="Cannot adapt shifted fixed-width histograms"
-            ):
-                b2.adapt(b1)
+                b1.coerce(b2)
 
-            b3 = binnings.FixedWidthBinning(
-                bin_width=5, bin_count=6, min=0, adaptive=True
-            )
-            with pytest.raises(ValueError):
-                b1.adapt(b3)
-            with pytest.raises(ValueError):
-                b3.adapt(b1)
+            b3 = binnings.FixedWidthBinning(bin_width=5, bin_count=6, times_min=0)
+            with pytest.raises(
+                ValueError,
+                match="Cannot coerce fixed-width histograms with different bin widths",
+            ):
+                b1.coerce(b3)
 
 
 class TestPrettyBins:

--- a/tests/test_binning.py
+++ b/tests/test_binning.py
@@ -3,6 +3,7 @@ import pytest
 
 from physt import binnings
 from physt._construction import calculate_nd_bins
+from physt.binnings import FixedWidthBinning
 
 
 class TestCalculateBinsNd:
@@ -45,6 +46,10 @@ class TestNumpyBins:
 
 
 class TestFixedWidthBins:
+    @pytest.fixture
+    def fixed_width_binning(self) -> FixedWidthBinning:
+        return binnings.FixedWidthBinning(bin_count=2, times_min=0)
+
     def test_without_alignment(self):
         data = np.asarray([4.6, 7.3])
         the_binning = binnings.fixed_width_binning(data, 1.0, align=False)
@@ -55,21 +60,19 @@ class TestFixedWidthBins:
         the_binning = binnings.fixed_width_binning(data, 1.0, align=True)
         assert np.allclose(the_binning.numpy_bins, [4, 5, 6, 7, 8])
 
-    def test_adapt_extension(self):
+    def test_adapt_extension(self, fixed_width_binning):
         b = binnings.FixedWidthBinning(bin_width=10, bin_count=3, min=0, adaptive=True)
-        b2 = binnings.FixedWidthBinning(bin_width=10, bin_count=2, min=0, adaptive=True)
-        m1, m2 = b2.adapt(b)
+        m1, m2 = fixed_width_binning.adapt(b)
         assert tuple(m1) == ((0, 0), (1, 1))
         assert m2 is None
-        assert np.array_equal(b2.numpy_bins, [0, 10, 20, 30])
-        assert b2.bin_count == 3
+        assert np.array_equal(fixed_width_binning.numpy_bins, [0, 10, 20, 30])
+        assert fixed_width_binning.bin_count == 3
 
-    def test_adapt_left(self):
-        b = binnings.FixedWidthBinning(bin_width=10, bin_count=3, min=0, adaptive=True)
+    def test_adapt_left(self, fixed_width_binning):
         b3 = binnings.FixedWidthBinning(
             bin_width=10, bin_count=2, min=50, adaptive=True
         )
-        m1, m2 = b3.adapt(b)
+        m1, m2 = b3.adapt(fixed_width_binning)
         assert tuple(m1) == ((0, 5), (1, 6))
         assert tuple(m2) == ((0, 0), (1, 1), (2, 2))
         assert b3.bin_count == 7

--- a/tests/test_binning.py
+++ b/tests/test_binning.py
@@ -143,25 +143,26 @@ class TestFixedWidthBins:
 
 
 class TestPrettyBins:
-    def test_exact(self):
-        data = np.random.rand(1000)
-        the_binning = binnings.pretty_binning(data, 10)
-        assert np.allclose(the_binning.numpy_bins, np.linspace(0, 1, 11))
+    @pytest.fixture
+    def data(self) -> np.ndarray:
+        return np.random.rand(1000)
 
-        the_binning = binnings.pretty_binning(data, 9)
-        assert np.allclose(the_binning.numpy_bins, np.linspace(0, 1, 11))
+    @pytest.mark.parametrize("bin_suggestion", [9, 10, 11])
+    def test_exact(self, data, bin_suggestion):
+        binning = binnings.pretty_binning(data, bin_suggestion)
+        assert np.allclose(binning.numpy_bins, np.linspace(0, 1, 11))
 
-        the_binning = binnings.pretty_binning(data, 11)
-        assert np.allclose(the_binning.numpy_bins, np.linspace(0, 1, 11))
+    def test_min_max_bin_width(self, data):
+        binning = binnings.pretty_binning(data, min_bin_width=0.3)
+        assert binning.bin_width == 0.3
 
-    def test_min_max_bin_width(self):
-        data = np.random.rand(1000)
+    def test_max_bin_width(self, data):
+        binning = binnings.pretty_binning(data, max_bin_width=0.001)
+        assert binning.bin_width == 0.001
 
-        the_binning = binnings.pretty_binning(data, min_bin_width=0.3)
-        assert the_binning.bin_width == 0.3
-
-        the_binning = binnings.pretty_binning(data, max_bin_width=0.001)
-        assert the_binning.bin_width == 0.001
+    def test_with_range(self, data):
+        binning = binnings.pretty_binning(data, range=[0.1, 0.9])
+        assert binning.bin_width == 0.1
 
 
 class TestIntegerBins:

--- a/tests/test_binning.py
+++ b/tests/test_binning.py
@@ -46,103 +46,124 @@ class TestNumpyBins:
 
 
 class TestFixedWidthBins:
-    @pytest.fixture
-    def fixed_width_binning(self) -> FixedWidthBinning:
-        return binnings.FixedWidthBinning(bin_count=2, times_min=0)
+    class TestHelper:
+        def test_without_alignment(self):
+            data = np.asarray([4.6, 7.3])
+            the_binning = binnings.fixed_width_binning(data, 1.0, align=False)
+            assert np.allclose(the_binning.numpy_bins, [4.6, 5.6, 6.6, 7.6])
 
-    def test_without_alignment(self):
-        data = np.asarray([4.6, 7.3])
-        the_binning = binnings.fixed_width_binning(data, 1.0, align=False)
-        assert np.allclose(the_binning.numpy_bins, [4.6, 5.6, 6.6, 7.6])
+        def test_with_alignment(self):
+            data = np.asarray([4.6, 7.3])
+            the_binning = binnings.fixed_width_binning(data, 1.0, align=True)
+            assert np.allclose(the_binning.numpy_bins, [4, 5, 6, 7, 8])
 
-    def test_with_alignment(self):
-        data = np.asarray([4.6, 7.3])
-        the_binning = binnings.fixed_width_binning(data, 1.0, align=True)
-        assert np.allclose(the_binning.numpy_bins, [4, 5, 6, 7, 8])
+    class TestCoercion:
+        @pytest.fixture
+        def fixed_width_binning(self) -> FixedWidthBinning:
+            # Bins: [0, 10, 20]
+            return binnings.FixedWidthBinning(bin_width=10, bin_count=2, times_min=0)
 
-    def test_adapt_extension(self, fixed_width_binning):
-        b = binnings.FixedWidthBinning(bin_width=10, bin_count=3, min=0, adaptive=True)
-        m1, m2 = fixed_width_binning.adapt(b)
-        assert tuple(m1) == ((0, 0), (1, 1))
-        assert m2 is None
-        assert np.array_equal(fixed_width_binning.numpy_bins, [0, 10, 20, 30])
-        assert fixed_width_binning.bin_count == 3
+        def test_coerce_extension(self, fixed_width_binning):
+            other = binnings.FixedWidthBinning(bin_width=10, bin_count=3, times_min=0)
+            new, m1, m2 = fixed_width_binning.coerce(other)
+            assert m1 == 0
+            assert m2 == 0
+            assert np.array_equal(new.numpy_bins, [0, 10, 20, 30])
+            assert new.bin_count == 3
 
-    def test_adapt_left(self, fixed_width_binning):
-        b3 = binnings.FixedWidthBinning(
-            bin_width=10, bin_count=2, min=50, adaptive=True
-        )
-        m1, m2 = b3.adapt(fixed_width_binning)
-        assert tuple(m1) == ((0, 5), (1, 6))
-        assert tuple(m2) == ((0, 0), (1, 1), (2, 2))
-        assert b3.bin_count == 7
+        def test_coerce_left(self, fixed_width_binning):
+            other = binnings.FixedWidthBinning(
+                bin_width=10,
+                bin_count=2,
+                times_min=-1,
+            )
+            new, m1, m2 = fixed_width_binning.coerce(other)
+            assert m1 == 1  # TODO: Validate the value
+            assert m2 == 0
+            assert new.bin_count == 3
 
-    def test_adapt_right(self):
-        b = binnings.FixedWidthBinning(bin_width=10, bin_count=3, min=0, adaptive=True)
-        b4 = binnings.FixedWidthBinning(
-            bin_width=10, bin_count=2, min=-30, adaptive=True
-        )
-        m1, m2 = b4.adapt(b)
-        assert tuple(m1) == ((0, 0), (1, 1))
-        assert tuple(m2) == ((0, 3), (1, 4), (2, 5))
-        assert b4.bin_count == 6
+        def test_adapt_right(self):
+            b = binnings.FixedWidthBinning(
+                bin_width=10, bin_count=3, min=0, adaptive=True
+            )
+            b4 = binnings.FixedWidthBinning(
+                bin_width=10, bin_count=2, min=-30, adaptive=True
+            )
+            m1, m2 = b4.adapt(b)
+            assert tuple(m1) == ((0, 0), (1, 1))
+            assert tuple(m2) == ((0, 3), (1, 4), (2, 5))
+            assert b4.bin_count == 6
 
-    def test_adapt_intersection1(self):
-        b = binnings.FixedWidthBinning(bin_width=10, bin_count=3, min=0, adaptive=True)
-        b5 = binnings.FixedWidthBinning(
-            bin_width=10, bin_count=2, min=-10, adaptive=True
-        )
-        m1, m2 = b5.adapt(b)
-        assert tuple(m1) == ((0, 0), (1, 1))
-        assert tuple(m2) == ((0, 1), (1, 2), (2, 3))
-        assert b5.bin_count == 4
+        def test_adapt_intersection1(self):
+            b = binnings.FixedWidthBinning(
+                bin_width=10, bin_count=3, min=0, adaptive=True
+            )
+            b5 = binnings.FixedWidthBinning(
+                bin_width=10, bin_count=2, min=-10, adaptive=True
+            )
+            m1, m2 = b5.adapt(b)
+            assert tuple(m1) == ((0, 0), (1, 1))
+            assert tuple(m2) == ((0, 1), (1, 2), (2, 3))
+            assert b5.bin_count == 4
 
-    def test_adapt_intersection2(self):
-        b = binnings.FixedWidthBinning(bin_width=10, bin_count=3, min=0, adaptive=True)
-        b6 = binnings.FixedWidthBinning(
-            bin_width=10, bin_count=3, min=10, adaptive=True
-        )
-        m1, m2 = b6.adapt(b)
-        assert tuple(m1) == ((0, 1), (1, 2), (2, 3))
-        assert tuple(m2) == ((0, 0), (1, 1), (2, 2))
-        assert b6.bin_count == 4
+        def test_adapt_intersection2(self):
+            b = binnings.FixedWidthBinning(
+                bin_width=10, bin_count=3, min=0, adaptive=True
+            )
+            b6 = binnings.FixedWidthBinning(
+                bin_width=10, bin_count=3, min=10, adaptive=True
+            )
+            m1, m2 = b6.adapt(b)
+            assert tuple(m1) == ((0, 1), (1, 2), (2, 3))
+            assert tuple(m2) == ((0, 0), (1, 1), (2, 2))
+            assert b6.bin_count == 4
 
-    def test_adapt_internal(self):
-        b1 = binnings.FixedWidthBinning(bin_width=10, bin_count=3, min=0, adaptive=True)
-        b2 = binnings.FixedWidthBinning(
-            bin_width=10, bin_count=1, min=10, adaptive=True
-        )
-        m1, m2 = b1.adapt(b2)
-        assert m1 is None
-        assert tuple(m2) == ((0, 1),)
+        def test_adapt_internal(self):
+            b1 = binnings.FixedWidthBinning(
+                bin_width=10, bin_count=3, min=0, adaptive=True
+            )
+            b2 = binnings.FixedWidthBinning(
+                bin_width=10, bin_count=1, min=10, adaptive=True
+            )
+            m1, m2 = b1.adapt(b2)
+            assert m1 is None
+            assert tuple(m2) == ((0, 1),)
 
-    def test_adapt_external(self):
-        b1 = binnings.FixedWidthBinning(
-            bin_width=10, bin_count=1, min=10, adaptive=True
-        )
-        b2 = binnings.FixedWidthBinning(bin_width=10, bin_count=3, min=0, adaptive=True)
-        m1, m2 = b1.adapt(b2)
-        assert tuple(m1) == ((0, 1),)
-        assert m2 is None
-        assert b1.bin_count == 3
+        def test_adapt_external(self):
+            b1 = binnings.FixedWidthBinning(
+                bin_width=10, bin_count=1, min=10, adaptive=True
+            )
+            b2 = binnings.FixedWidthBinning(
+                bin_width=10, bin_count=3, min=0, adaptive=True
+            )
+            m1, m2 = b1.adapt(b2)
+            assert tuple(m1) == ((0, 1),)
+            assert m2 is None
+            assert b1.bin_count == 3
 
-    def test_adapt_wrong(self):
-        b1 = binnings.FixedWidthBinning(bin_width=10, bin_count=2, min=0, adaptive=True)
-        b2 = binnings.FixedWidthBinning(bin_width=10, bin_count=2, min=1, adaptive=True)
-        with pytest.raises(
-            ValueError, match="Cannot adapt shifted fixed-width histograms"
-        ):
-            b1.adapt(b2)
-        with pytest.raises(
-            ValueError, match="Cannot adapt shifted fixed-width histograms"
-        ):
-            b2.adapt(b1)
+        def test_adapt_wrong(self):
+            b1 = binnings.FixedWidthBinning(
+                bin_width=10, bin_count=2, min=0, adaptive=True
+            )
+            b2 = binnings.FixedWidthBinning(
+                bin_width=10, bin_count=2, min=1, adaptive=True
+            )
+            with pytest.raises(
+                ValueError, match="Cannot adapt shifted fixed-width histograms"
+            ):
+                b1.adapt(b2)
+            with pytest.raises(
+                ValueError, match="Cannot adapt shifted fixed-width histograms"
+            ):
+                b2.adapt(b1)
 
-        b3 = binnings.FixedWidthBinning(bin_width=5, bin_count=6, min=0, adaptive=True)
-        with pytest.raises(ValueError):
-            b1.adapt(b3)
-        with pytest.raises(ValueError):
-            b3.adapt(b1)
+            b3 = binnings.FixedWidthBinning(
+                bin_width=5, bin_count=6, min=0, adaptive=True
+            )
+            with pytest.raises(ValueError):
+                b1.adapt(b3)
+            with pytest.raises(ValueError):
+                b3.adapt(b1)
 
 
 class TestPrettyBins:

--- a/tests/test_binning.py
+++ b/tests/test_binning.py
@@ -46,6 +46,14 @@ class TestNumpyBins:
 
 
 class TestFixedWidthBins:
+    @pytest.fixture
+    def fixed_width_binning(self) -> FixedWidthBinning:
+        # Bins: [0, 10, 20]
+        return binnings.FixedWidthBinning(bin_width=10, bin_count=2, times_min=0)
+
+    def test_numpy_bins(self, fixed_width_binning):
+        assert np.array_equal(fixed_width_binning.numpy_bins, [0, 10, 20])
+
     class TestHelper:
         def test_without_alignment(self):
             data = np.asarray([4.6, 7.3])
@@ -58,11 +66,6 @@ class TestFixedWidthBins:
             assert np.allclose(the_binning.numpy_bins, [4, 5, 6, 7, 8])
 
     class TestCoercion:
-        @pytest.fixture
-        def fixed_width_binning(self) -> FixedWidthBinning:
-            # Bins: [0, 10, 20]
-            return binnings.FixedWidthBinning(bin_width=10, bin_count=2, times_min=0)
-
         def test_coerce_extension(self, fixed_width_binning):
             other = binnings.FixedWidthBinning(bin_width=10, bin_count=3, times_min=0)
             new, m1, m2 = fixed_width_binning.coerce(other)
@@ -158,11 +161,15 @@ class TestPrettyBins:
 
 
 class TestIntegerBins:
-    def test_dice(self):
-        data = np.asarray([1, 2, 3, 5, 6, 2, 4, 3, 2, 3, 4, 5, 6, 6, 1, 2, 5])
+    @pytest.fixture
+    def data(self) -> np.ndarray:
+        np.asarray([1, 2, 3, 5, 6, 2, 4, 3, 2, 3, 4, 5, 6, 6, 1, 2, 5])
+
+    def test_dice(self, data):
         the_binning = binnings.integer_binning(data)
         assert np.allclose(the_binning.numpy_bins, [0.5, 1.5, 2.5, 3.5, 4.5, 5.5, 6.5])
 
+    def test_with_range(self, data):
         the_binning = binnings.integer_binning(data, range=(1, 6))
         assert np.allclose(the_binning.numpy_bins, [0.5, 1.5, 2.5, 3.5, 4.5, 5.5])
 

--- a/tests/test_binning.py
+++ b/tests/test_binning.py
@@ -49,7 +49,7 @@ class TestFixedWidthBins:
     @pytest.fixture
     def fixed_width_binning(self) -> FixedWidthBinning:
         # Bins: [0, 10, 20]
-        return binnings.FixedWidthBinning(bin_width=10, bin_count=2, times_min=0)
+        return binnings.FixedWidthBinning(bin_width=10, bin_count=2, bin_times_min=0)
 
     def test_numpy_bins(self, fixed_width_binning):
         assert np.array_equal(fixed_width_binning.numpy_bins, [0, 10, 20])
@@ -67,7 +67,9 @@ class TestFixedWidthBins:
 
     class TestCoercion:
         def test_coerce_extension(self, fixed_width_binning):
-            other = binnings.FixedWidthBinning(bin_width=10, bin_count=3, times_min=0)
+            other = binnings.FixedWidthBinning(
+                bin_width=10, bin_count=3, bin_times_min=0
+            )
             new, m1, m2 = fixed_width_binning.coerce(other)
             assert m1 == 0
             assert m2 == 0
@@ -77,7 +79,7 @@ class TestFixedWidthBins:
             other = binnings.FixedWidthBinning(
                 bin_width=10,
                 bin_count=2,
-                times_min=-1,
+                bin_times_min=-1,
             )
             # Bins: [-10, 0, 10]
             new, m1, m2 = fixed_width_binning.coerce(other)
@@ -89,7 +91,7 @@ class TestFixedWidthBins:
             other = binnings.FixedWidthBinning(
                 bin_width=10,
                 bin_count=2,
-                times_min=1,
+                bin_times_min=1,
             )
             # Bins: [10, 20, 30]
             new, m1, m2 = fixed_width_binning.coerce(other)
@@ -101,7 +103,7 @@ class TestFixedWidthBins:
             other = binnings.FixedWidthBinning(
                 bin_width=10,
                 bin_count=1,
-                times_min=3,
+                bin_times_min=3,
             )
             # Bins: [30, 40]
             new, m1, m2 = fixed_width_binning.coerce(other)
@@ -110,7 +112,9 @@ class TestFixedWidthBins:
             assert np.array_equal(new.numpy_bins, [0, 10, 20, 30, 40])
 
         def test_coerce_subset(self, fixed_width_binning):
-            other = binnings.FixedWidthBinning(bin_width=10, bin_count=4, times_min=-1)
+            other = binnings.FixedWidthBinning(
+                bin_width=10, bin_count=4, bin_times_min=-1
+            )
             new1, m1, m2 = fixed_width_binning.coerce(other)
             assert m1 == 1
             assert m2 == 0
@@ -121,16 +125,16 @@ class TestFixedWidthBins:
             assert new1 == new2
 
         def test_coerce_invalid(self):
-            b1 = binnings.FixedWidthBinning(bin_width=10, bin_count=2, times_min=0)
+            b1 = binnings.FixedWidthBinning(bin_width=10, bin_count=2, bin_times_min=0)
             b2 = binnings.FixedWidthBinning(
-                bin_width=10, bin_count=2, times_min=0, shift=1
+                bin_width=10, bin_count=2, bin_times_min=0, bin_shift=1
             )
             with pytest.raises(
                 ValueError, match="Cannot coerce shifted fixed-width histograms"
             ):
                 b1.coerce(b2)
 
-            b3 = binnings.FixedWidthBinning(bin_width=5, bin_count=6, times_min=0)
+            b3 = binnings.FixedWidthBinning(bin_width=5, bin_count=6, bin_times_min=0)
             with pytest.raises(
                 ValueError,
                 match="Cannot coerce fixed-width histograms with different bin widths",

--- a/tests/test_binning.py
+++ b/tests/test_binning.py
@@ -163,7 +163,7 @@ class TestPrettyBins:
 class TestIntegerBins:
     @pytest.fixture
     def data(self) -> np.ndarray:
-        np.asarray([1, 2, 3, 5, 6, 2, 4, 3, 2, 3, 4, 5, 6, 6, 1, 2, 5])
+        return np.asarray([1, 2, 3, 5, 6, 2, 4, 3, 2, 3, 4, 5, 6, 6, 1, 2, 5])
 
     def test_dice(self, data):
         the_binning = binnings.integer_binning(data)

--- a/tests/test_histogram2d.py
+++ b/tests/test_histogram2d.py
@@ -6,19 +6,20 @@ from physt import binnings, h2, histogram_nd
 from physt.binnings import BinningBase, as_binning
 from physt.histogram_nd import Histogram2D
 
-vals = np.asarray(
-    [
-        [0.1, 2.0],
-        [-0.1, 0.7],
-        [0.2, 1.5],
-        [0.2, -1.5],
-        [0.2, 1.47],
-        [1.2, 1.23],
-        [0.7, 0.5],
-    ]
-)
 
-np.random.seed(42)
+@pytest.fixture
+def values() -> np.ndarray:
+    return np.asarray(
+        [
+            [0.1, 1.9],
+            [-0.1, 0.7],
+            [0.2, 1.5],
+            [0.2, -1.5],
+            [0.2, 1.47],
+            [1.2, 1.23],
+            [0.7, 0.5],
+        ]
+    )
 
 
 @pytest.fixture
@@ -37,33 +38,36 @@ def h3x3(bins0to3, a3x3) -> Histogram2D:
     return Histogram2D(binnings=[bins0to3, bins0to3], frequencies=a3x3)
 
 
+np.random.seed(42)
+
+
 class TestCalculateFrequencies:
-    def test_simple(self):
+    def test_simple(self, values):
         bins = [[0, 1, 2], [0, 1, 2]]
         schemas = [binnings.static_binning(None, bins=np.asarray(bs)) for bs in bins]
         frequencies, errors2, missing = histogram_nd.calculate_nd_frequencies(
-            vals, binnings=schemas
+            values, binnings=schemas
         )
         assert np.array_equal([[1, 3], [0, 1]], frequencies)
         assert missing == 2
         assert errors2 is None
 
-    def test_gap(self):
+    def test_gap(self, values):
         bins = [[[-1, 0], [1, 2]], [[-2, -1], [1, 2]]]
         schemas = [binnings.static_binning(None, bins=np.asarray(bs)) for bs in bins]
         frequencies, errors2, missing = histogram_nd.calculate_nd_frequencies(
-            vals, binnings=schemas
+            values, binnings=schemas
         )
         assert np.array_equal([[0, 0], [0, 1]], frequencies)
         assert missing == 6
         assert errors2 is None
 
-    def test_errors(self):
+    def test_errors(self, values):
         bins = [[[-1, 0], [1, 2]], [[-2, -1], [1, 2]]]
         weights = np.asarray([2, 1, 1, 1, 1, 2, 1])
         schemas = [binnings.static_binning(None, bins=np.asarray(bs)) for bs in bins]
         frequencies, errors2, missing = histogram_nd.calculate_nd_frequencies(
-            vals, binnings=schemas, weights=weights
+            values, binnings=schemas, weights=weights
         )
         assert np.array_equal([[0, 0], [0, 2]], frequencies)
         assert missing == 7
@@ -80,14 +84,13 @@ class TestHistogram2D:
         assert h2.name == "Some histogram"
         assert h2.axis_names == ("x", "y")
 
-    def test_dropna(self):
-        vals2 = np.array(vals)
-        vals2[0, 1] = np.nan
+    def test_dropna(self, values):
+        values[0, 1] = np.nan
         with pytest.raises(
             ValueError, match="Cannot calculate bins in presence of NaN's"
         ):
-            hist = physt.h2(vals2[:, 0], vals2[:, 1], dropna=False)
-        hist = physt.h2(vals2[:, 0], vals2[:, 1])
+            physt.h2(values[:, 0], values[:, 1], dropna=False)
+        hist = physt.h2(values[:, 0], values[:, 1])
         assert hist.frequencies.sum() == 6
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -75,11 +75,11 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "astropy-iers-data", marker = "python_full_version < '3.11'" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "packaging", marker = "python_full_version < '3.11'" },
-    { name = "pyerfa", marker = "python_full_version < '3.11'" },
-    { name = "pyyaml", marker = "python_full_version < '3.11'" },
+    { name = "astropy-iers-data" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
+    { name = "packaging" },
+    { name = "pyerfa" },
+    { name = "pyyaml" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/8a/f8/9c6675ab4c646b95aae2762d108f6be4504033d91bd50da21daa62cab5ce/astropy-6.1.7.tar.gz", hash = "sha256:a405ac186306b6cb152e6df2f7444ab8bd764e4127d7519da1b3ae4dd65357ef", size = 7063411, upload-time = "2024-11-22T21:22:34.373Z" }
 wheels = [
@@ -132,12 +132,12 @@ resolution-markers = [
     "python_full_version == '3.11.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "astropy-iers-data", marker = "python_full_version >= '3.11'" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
+    { name = "astropy-iers-data" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
     { name = "numpy", version = "2.5.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
-    { name = "packaging", marker = "python_full_version >= '3.11'" },
-    { name = "pyerfa", marker = "python_full_version >= '3.11'" },
-    { name = "pyyaml", marker = "python_full_version >= '3.11'" },
+    { name = "packaging" },
+    { name = "pyerfa" },
+    { name = "pyyaml" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0e/c4/21be4313ddfde5f60e0607fd307f367b9e0f0bf153a89b10cbd036dd8cfd/astropy-8.0.1.tar.gz", hash = "sha256:45ca31d5b91fa294cd590a4791a32db94de7f9c8a343155f4d5877baa82351da", size = 7152500, upload-time = "2026-07-05T07:24:48.482Z" }
 wheels = [
@@ -270,7 +270,7 @@ name = "cffi"
 version = "2.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pycparser", marker = "implementation_name != 'PyPy'" },
+    { name = "pycparser" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/57/5f/ff100cae70ebe9d8df1c01a00e510e45d9adb5c1fdda84791b199141de97/cffi-2.1.0.tar.gz", hash = "sha256:efc1cdd798b1aaf39b4610bba7aad28c9bea9b910f25c784ccf9ec1fa719d1f9", size = 531036, upload-time = "2026-07-06T21:34:30.382Z" }
 wheels = [
@@ -500,7 +500,7 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/66/54/eb9bfc647b19f2009dd5c7f5ec51c4e6ca831725f1aea7a993034f483147/contourpy-1.3.2.tar.gz", hash = "sha256:b6945942715a034c671b7fc54f9588126b0b8bf23db2696e3ca8328f3ff0ab54", size = 13466130, upload-time = "2025-04-15T17:47:53.79Z" }
 wheels = [
@@ -581,7 +581,7 @@ resolution-markers = [
     "python_full_version == '3.11.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
     { name = "numpy", version = "2.5.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/58/01/1253e6698a07380cd31a736d248a3f2a50a7c88779a1813da27503cadc2a/contourpy-1.3.3.tar.gz", hash = "sha256:083e12155b210502d0bca491432bb04d56dc3432f95a979b429f2848c3dbe880", size = 13466174, upload-time = "2025-07-26T12:03:12.549Z" }
@@ -752,7 +752,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -952,7 +952,7 @@ name = "importlib-metadata"
 version = "9.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "zipp", marker = "python_full_version < '3.12'" },
+    { name = "zipp" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a9/01/15bb152d77b21318514a96f43af312635eb2500c96b55398d020c93d86ea/importlib_metadata-9.0.0.tar.gz", hash = "sha256:a4f57ab599e6a2e3016d7595cfd72eb4661a5106e787a95bcc90c7105b831efc", size = 56405, upload-time = "2026-03-20T06:42:56.999Z" }
 wheels = [
@@ -976,17 +976,17 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "colorama", marker = "python_full_version < '3.11' and sys_platform == 'win32'" },
-    { name = "decorator", marker = "python_full_version < '3.11'" },
-    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
-    { name = "jedi", marker = "python_full_version < '3.11'" },
-    { name = "matplotlib-inline", marker = "python_full_version < '3.11'" },
-    { name = "pexpect", marker = "python_full_version < '3.11' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
-    { name = "prompt-toolkit", marker = "python_full_version < '3.11'" },
-    { name = "pygments", marker = "python_full_version < '3.11'" },
-    { name = "stack-data", marker = "python_full_version < '3.11'" },
-    { name = "traitlets", marker = "python_full_version < '3.11'" },
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "decorator" },
+    { name = "exceptiongroup" },
+    { name = "jedi" },
+    { name = "matplotlib-inline" },
+    { name = "pexpect", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "prompt-toolkit" },
+    { name = "pygments" },
+    { name = "stack-data" },
+    { name = "traitlets" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/40/18/f8598d287006885e7136451fdea0755af4ebcbfe342836f24deefaed1164/ipython-8.39.0.tar.gz", hash = "sha256:4110ae96012c379b8b6db898a07e186c40a2a1ef5d57a7fa83166047d9da7624", size = 5513971, upload-time = "2026-03-27T10:02:13.94Z" }
 wheels = [
@@ -1012,18 +1012,18 @@ resolution-markers = [
     "python_full_version == '3.11.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "colorama", marker = "python_full_version >= '3.11' and sys_platform == 'win32'" },
-    { name = "decorator", marker = "python_full_version >= '3.11'" },
-    { name = "ipython-pygments-lexers", marker = "python_full_version >= '3.11'" },
-    { name = "jedi", marker = "python_full_version >= '3.11'" },
-    { name = "matplotlib-inline", marker = "python_full_version >= '3.11'" },
-    { name = "pexpect", marker = "python_full_version >= '3.11' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
-    { name = "prompt-toolkit", marker = "python_full_version >= '3.11'" },
-    { name = "psutil", marker = "python_full_version >= '3.11' and sys_platform != 'cygwin' and sys_platform != 'emscripten'" },
-    { name = "pygments", marker = "python_full_version >= '3.11'" },
-    { name = "stack-data", marker = "python_full_version >= '3.11'" },
-    { name = "traitlets", marker = "python_full_version >= '3.11'" },
-    { name = "typing-extensions", marker = "python_full_version == '3.11.*'" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "decorator" },
+    { name = "ipython-pygments-lexers" },
+    { name = "jedi" },
+    { name = "matplotlib-inline" },
+    { name = "pexpect", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "prompt-toolkit" },
+    { name = "psutil", marker = "sys_platform != 'cygwin' and sys_platform != 'emscripten'" },
+    { name = "pygments" },
+    { name = "stack-data" },
+    { name = "traitlets" },
+    { name = "typing-extensions", marker = "python_full_version < '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/53/59/165d3b4d75cc34add3122c4417ecb229085140ac573103c223cd01dde96f/ipython-9.15.0.tar.gz", hash = "sha256:da2819ce2aa83135257df830660b1176d986c3d2876db24df01974fa955b2756", size = 4442580, upload-time = "2026-06-26T11:03:35.913Z" }
 wheels = [
@@ -1035,7 +1035,7 @@ name = "ipython-pygments-lexers"
 version = "1.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pygments", marker = "python_full_version >= '3.11'" },
+    { name = "pygments" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ef/4c/5dd1d8af08107f88c7f741ead7a40854b8ac24ddf9ae850afbcf698aa552/ipython_pygments_lexers-1.1.1.tar.gz", hash = "sha256:09c0138009e56b6854f9535736f4171d855c8c08a563a0dcd8022f78355c7e81", size = 8393, upload-time = "2025-01-17T11:24:34.505Z" }
 wheels = [
@@ -1467,15 +1467,15 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "contourpy", version = "1.3.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "cycler", marker = "python_full_version < '3.11'" },
-    { name = "fonttools", marker = "python_full_version < '3.11'" },
-    { name = "kiwisolver", marker = "python_full_version < '3.11'" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "packaging", marker = "python_full_version < '3.11'" },
-    { name = "pillow", marker = "python_full_version < '3.11'" },
-    { name = "pyparsing", marker = "python_full_version < '3.11'" },
-    { name = "python-dateutil", marker = "python_full_version < '3.11'" },
+    { name = "contourpy", version = "1.3.2", source = { registry = "https://pypi.org/simple" } },
+    { name = "cycler" },
+    { name = "fonttools" },
+    { name = "kiwisolver" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
+    { name = "packaging" },
+    { name = "pillow" },
+    { name = "pyparsing" },
+    { name = "python-dateutil" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/63/1b/4be5be87d43d327a0cf4de1a56e86f7f84c89312452406cf122efe2839e6/matplotlib-3.10.9.tar.gz", hash = "sha256:fd66508e8c6877d98e586654b608a0456db8d7e8a546eb1e2600efd957302358", size = 34811233, upload-time = "2026-04-24T00:14:13.539Z" }
 wheels = [
@@ -1554,16 +1554,16 @@ resolution-markers = [
     "python_full_version == '3.11.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "contourpy", version = "1.3.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "cycler", marker = "python_full_version >= '3.11'" },
-    { name = "fonttools", marker = "python_full_version >= '3.11'" },
-    { name = "kiwisolver", marker = "python_full_version >= '3.11'" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
+    { name = "contourpy", version = "1.3.3", source = { registry = "https://pypi.org/simple" } },
+    { name = "cycler" },
+    { name = "fonttools" },
+    { name = "kiwisolver" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
     { name = "numpy", version = "2.5.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
-    { name = "packaging", marker = "python_full_version >= '3.11'" },
-    { name = "pillow", marker = "python_full_version >= '3.11'" },
-    { name = "pyparsing", marker = "python_full_version >= '3.11'" },
-    { name = "python-dateutil", marker = "python_full_version >= '3.11'" },
+    { name = "packaging" },
+    { name = "pillow" },
+    { name = "pyparsing" },
+    { name = "python-dateutil" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1f/24/080c99d223d158d3a8902769269ab6da5b50f7a0e6e072513907e02b7a6c/matplotlib-3.11.0.tar.gz", hash = "sha256:68c0c7be01b30dcca3638934f7f591df73401235cbdbf0d1ab1c71e7db7f8b57", size = 33251176, upload-time = "2026-06-12T02:29:15.508Z" }
 wheels = [
@@ -2043,10 +2043,10 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "python-dateutil", marker = "python_full_version < '3.11'" },
-    { name = "pytz", marker = "python_full_version < '3.11'" },
-    { name = "tzdata", marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
+    { name = "python-dateutil" },
+    { name = "pytz" },
+    { name = "tzdata" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/33/01/d40b85317f86cf08d853a4f495195c73815fdf205eef3993821720274518/pandas-2.3.3.tar.gz", hash = "sha256:e05e1af93b977f7eafa636d043f9f94c7ee3ac81af99c13508215942e64c993b", size = 4495223, upload-time = "2025-09-29T23:34:51.853Z" }
 wheels = [
@@ -2118,10 +2118,10 @@ resolution-markers = [
     "python_full_version == '3.11.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
     { name = "numpy", version = "2.5.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
-    { name = "python-dateutil", marker = "python_full_version >= '3.11'" },
-    { name = "tzdata", marker = "(python_full_version >= '3.11' and sys_platform == 'emscripten') or (python_full_version >= '3.11' and sys_platform == 'win32')" },
+    { name = "python-dateutil" },
+    { name = "tzdata", marker = "sys_platform == 'emscripten' or sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f8/87/4341c6252d1c47b08768c3d25ac487362bf403f0313ddae4a2a26c9b1b4c/pandas-3.0.3.tar.gz", hash = "sha256:696a4a00a2a2a35d4e5deb3fc946641b96c944f02230e4f76137fe35d806c4fc", size = 4651414, upload-time = "2026-05-11T18:54:29.21Z" }
 wheels = [
@@ -2231,7 +2231,7 @@ name = "pexpect"
 version = "4.9.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "ptyprocess", marker = "(python_full_version < '3.11' and sys_platform == 'emscripten') or (python_full_version < '3.11' and sys_platform == 'win32') or (sys_platform != 'emscripten' and sys_platform != 'win32')" },
+    { name = "ptyprocess" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/42/92/cc564bf6381ff43ce1f4d06852fc19a2f11d180f23dc32d9588bee2f149d/pexpect-4.9.0.tar.gz", hash = "sha256:ee7d41123f3c9911050ea2c2dac107568dc43b2d3b0c7557a33212c398ead30f", size = 166450, upload-time = "2023-11-25T09:07:26.339Z" }
 wheels = [
@@ -2243,6 +2243,7 @@ name = "physt"
 version = "0.9.0"
 source = { editable = "." }
 dependencies = [
+    { name = "attrs" },
     { name = "basedpyright" },
     { name = "click" },
     { name = "hypothesis" },
@@ -2321,6 +2322,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "astropy", marker = "extra == 'astropy'", specifier = ">=6.0" },
+    { name = "attrs", specifier = ">=26.1.0" },
     { name = "basedpyright", specifier = ">=1.39.9" },
     { name = "click", specifier = ">=8.1.8" },
     { name = "dask", extras = ["array"], marker = "extra == 'dask'", specifier = ">=2023.0" },
@@ -3169,23 +3171,23 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "alabaster", marker = "python_full_version < '3.11'" },
-    { name = "babel", marker = "python_full_version < '3.11'" },
-    { name = "colorama", marker = "python_full_version < '3.11' and sys_platform == 'win32'" },
-    { name = "docutils", version = "0.21.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "imagesize", marker = "python_full_version < '3.11'" },
-    { name = "jinja2", marker = "python_full_version < '3.11'" },
-    { name = "packaging", marker = "python_full_version < '3.11'" },
-    { name = "pygments", marker = "python_full_version < '3.11'" },
-    { name = "requests", marker = "python_full_version < '3.11'" },
-    { name = "snowballstemmer", marker = "python_full_version < '3.11'" },
-    { name = "sphinxcontrib-applehelp", marker = "python_full_version < '3.11'" },
-    { name = "sphinxcontrib-devhelp", marker = "python_full_version < '3.11'" },
-    { name = "sphinxcontrib-htmlhelp", marker = "python_full_version < '3.11'" },
-    { name = "sphinxcontrib-jsmath", marker = "python_full_version < '3.11'" },
-    { name = "sphinxcontrib-qthelp", marker = "python_full_version < '3.11'" },
-    { name = "sphinxcontrib-serializinghtml", marker = "python_full_version < '3.11'" },
-    { name = "tomli", marker = "python_full_version < '3.11'" },
+    { name = "alabaster" },
+    { name = "babel" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "docutils", version = "0.21.2", source = { registry = "https://pypi.org/simple" } },
+    { name = "imagesize" },
+    { name = "jinja2" },
+    { name = "packaging" },
+    { name = "pygments" },
+    { name = "requests" },
+    { name = "snowballstemmer" },
+    { name = "sphinxcontrib-applehelp" },
+    { name = "sphinxcontrib-devhelp" },
+    { name = "sphinxcontrib-htmlhelp" },
+    { name = "sphinxcontrib-jsmath" },
+    { name = "sphinxcontrib-qthelp" },
+    { name = "sphinxcontrib-serializinghtml" },
+    { name = "tomli" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/be0b61178fe2cdcb67e2a92fc9ebb488e3c51c4f74a36a7824c0adf23425/sphinx-8.1.3.tar.gz", hash = "sha256:43c1911eecb0d3e161ad78611bc905d1ad0e523e4ddc202a58a821773dc4c927", size = 8184611, upload-time = "2024-10-13T20:27:13.93Z" }
 wheels = [
@@ -3202,23 +3204,23 @@ resolution-markers = [
     "python_full_version == '3.11.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "alabaster", marker = "python_full_version == '3.11.*'" },
-    { name = "babel", marker = "python_full_version == '3.11.*'" },
-    { name = "colorama", marker = "python_full_version == '3.11.*' and sys_platform == 'win32'" },
-    { name = "docutils", version = "0.22.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
-    { name = "imagesize", marker = "python_full_version == '3.11.*'" },
-    { name = "jinja2", marker = "python_full_version == '3.11.*'" },
-    { name = "packaging", marker = "python_full_version == '3.11.*'" },
-    { name = "pygments", marker = "python_full_version == '3.11.*'" },
-    { name = "requests", marker = "python_full_version == '3.11.*'" },
-    { name = "roman-numerals", marker = "python_full_version == '3.11.*'" },
-    { name = "snowballstemmer", marker = "python_full_version == '3.11.*'" },
-    { name = "sphinxcontrib-applehelp", marker = "python_full_version == '3.11.*'" },
-    { name = "sphinxcontrib-devhelp", marker = "python_full_version == '3.11.*'" },
-    { name = "sphinxcontrib-htmlhelp", marker = "python_full_version == '3.11.*'" },
-    { name = "sphinxcontrib-jsmath", marker = "python_full_version == '3.11.*'" },
-    { name = "sphinxcontrib-qthelp", marker = "python_full_version == '3.11.*'" },
-    { name = "sphinxcontrib-serializinghtml", marker = "python_full_version == '3.11.*'" },
+    { name = "alabaster" },
+    { name = "babel" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "docutils", version = "0.22.4", source = { registry = "https://pypi.org/simple" } },
+    { name = "imagesize" },
+    { name = "jinja2" },
+    { name = "packaging" },
+    { name = "pygments" },
+    { name = "requests" },
+    { name = "roman-numerals" },
+    { name = "snowballstemmer" },
+    { name = "sphinxcontrib-applehelp" },
+    { name = "sphinxcontrib-devhelp" },
+    { name = "sphinxcontrib-htmlhelp" },
+    { name = "sphinxcontrib-jsmath" },
+    { name = "sphinxcontrib-qthelp" },
+    { name = "sphinxcontrib-serializinghtml" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/42/50/a8c6ccc36d5eacdfd7913ddccd15a9cee03ecafc5ee2bc40e1f168d85022/sphinx-9.0.4.tar.gz", hash = "sha256:594ef59d042972abbc581d8baa577404abe4e6c3b04ef61bd7fc2acbd51f3fa3", size = 8710502, upload-time = "2025-12-04T07:45:27.343Z" }
 wheels = [
@@ -3241,23 +3243,23 @@ resolution-markers = [
     "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "alabaster", marker = "python_full_version >= '3.12'" },
-    { name = "babel", marker = "python_full_version >= '3.12'" },
-    { name = "colorama", marker = "python_full_version >= '3.12' and sys_platform == 'win32'" },
-    { name = "docutils", version = "0.22.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
-    { name = "imagesize", marker = "python_full_version >= '3.12'" },
-    { name = "jinja2", marker = "python_full_version >= '3.12'" },
-    { name = "packaging", marker = "python_full_version >= '3.12'" },
-    { name = "pygments", marker = "python_full_version >= '3.12'" },
-    { name = "requests", marker = "python_full_version >= '3.12'" },
-    { name = "roman-numerals", marker = "python_full_version >= '3.12'" },
-    { name = "snowballstemmer", marker = "python_full_version >= '3.12'" },
-    { name = "sphinxcontrib-applehelp", marker = "python_full_version >= '3.12'" },
-    { name = "sphinxcontrib-devhelp", marker = "python_full_version >= '3.12'" },
-    { name = "sphinxcontrib-htmlhelp", marker = "python_full_version >= '3.12'" },
-    { name = "sphinxcontrib-jsmath", marker = "python_full_version >= '3.12'" },
-    { name = "sphinxcontrib-qthelp", marker = "python_full_version >= '3.12'" },
-    { name = "sphinxcontrib-serializinghtml", marker = "python_full_version >= '3.12'" },
+    { name = "alabaster" },
+    { name = "babel" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "docutils", version = "0.22.4", source = { registry = "https://pypi.org/simple" } },
+    { name = "imagesize" },
+    { name = "jinja2" },
+    { name = "packaging" },
+    { name = "pygments" },
+    { name = "requests" },
+    { name = "roman-numerals" },
+    { name = "snowballstemmer" },
+    { name = "sphinxcontrib-applehelp" },
+    { name = "sphinxcontrib-devhelp" },
+    { name = "sphinxcontrib-htmlhelp" },
+    { name = "sphinxcontrib-jsmath" },
+    { name = "sphinxcontrib-qthelp" },
+    { name = "sphinxcontrib-serializinghtml" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/cd/bd/f08eb0f4eed5c83f1ba2a3bd18f7745a2b1525fad70660a1c00224ec468a/sphinx-9.1.0.tar.gz", hash = "sha256:7741722357dd75f8190766926071fed3bdc211c74dd2d7d4df5404da95930ddb", size = 8718324, upload-time = "2025-12-31T15:09:27.646Z" }
 wheels = [
@@ -3541,9 +3543,9 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "packaging", marker = "python_full_version < '3.11'" },
-    { name = "pandas", version = "2.3.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
+    { name = "packaging" },
+    { name = "pandas", version = "2.3.3", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/19/ec/e50d833518f10b0c24feb184b209bb6856f25b919ba8c1f89678b930b1cd/xarray-2025.6.1.tar.gz", hash = "sha256:a84f3f07544634a130d7dc615ae44175419f4c77957a7255161ed99c69c7c8b0", size = 3003185, upload-time = "2025-06-12T03:04:09.099Z" }
 wheels = [
@@ -3569,10 +3571,10 @@ resolution-markers = [
     "python_full_version == '3.11.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
     { name = "numpy", version = "2.5.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
-    { name = "packaging", marker = "python_full_version >= '3.11'" },
-    { name = "pandas", version = "3.0.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "packaging" },
+    { name = "pandas", version = "3.0.3", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/4b/a6/6fe936a798a3a38a79c7422d1a31afd2e9a14690fcb0ccff96bc01f04bf2/xarray-2026.4.0.tar.gz", hash = "sha256:c4ac9a01a945d90d5b1628e2af045099a9d4943536d4f2ee3ae963c3b222d15b", size = 3132311, upload-time = "2026-04-13T19:45:36.688Z" }
 wheels = [


### PR DESCRIPTION
Refactor binning instances to frozen attrs models.

This has a few consequences:
- they cannot change in-place, thus all changes in an adaptive histogram bins is performed as replacing one binning with another one
- instead of "adaptation", we call the operation "coercing" (with two different implementations for values and for another histogram)
- the API of BinningBase is slightly changed
- the semantics of includes_right_edge, align, range, ..., etc. in fixed_width_binning is slightly changed

Some other changes:
- the fixed width as the only adaptable

Testing:
- all tests pass
- all documentation notebooks render reasonably